### PR TITLE
feat: Add deploy script and workflow documentation

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -1,0 +1,77 @@
+# Flujo de Trabajo - Imporlan
+
+## Principios Fundamentales
+
+1. **GitHub es la ÚNICA fuente de verdad** - Todo el código vive en el repositorio
+2. **Nunca modificar producción directamente** - Solo se actualiza desde GitHub
+3. **Siempre probar en /test primero** - Validar antes de pasar a producción
+4. **Todo cambio queda versionado** - Commits claros y descriptivos
+
+## Estructura de Ambientes
+
+| Ambiente | URL | Propósito |
+|----------|-----|-----------|
+| TEST | https://www.imporlan.cl/test/ | Desarrollo y pruebas |
+| PRODUCCIÓN | https://www.imporlan.cl/ | Sitio en vivo |
+
+## Flujo de Desarrollo
+
+### Paso 1: Desarrollo en /test
+
+Todos los cambios se realizan primero en el ambiente de pruebas:
+- URL: https://www.imporlan.cl/test/
+- Panel Usuario: https://www.imporlan.cl/test/panel/
+- API: https://www.imporlan.cl/test/api/
+
+### Paso 2: Validación
+
+Verificar que todo funciona correctamente:
+- Landing page carga correctamente
+- Panel de usuario funciona
+- Panel de administración funciona
+- Correos se envían (a jpchs1@gmail.com en TEST)
+- Pagos funcionan (modo sandbox)
+- Imágenes cargan correctamente
+
+### Paso 3: Commit a GitHub
+
+Una vez aprobado por Juan Pablo, hacer commit con mensaje descriptivo y push a main.
+
+### Paso 4: Deploy a Producción
+
+Usar el endpoint de deploy (el token está en deploy_config.php en el servidor):
+
+- Deploy a TEST: `/api/deploy.php?env=test&token=TOKEN`
+- Deploy a PRODUCCIÓN: `/api/deploy.php?env=prod&token=TOKEN&confirm=yes`
+
+## Configuración de Correos
+
+### Ambiente TEST
+- Todos los correos se redirigen a: jpchs1@gmail.com
+- Permite probar flujos reales sin enviar a usuarios
+
+### Ambiente PRODUCCIÓN
+- Correos se envían a destinatarios reales
+- From: contacto@imporlan.cl
+
+La detección de ambiente es automática basada en la URL.
+
+## Archivos Protegidos
+
+Estos archivos NUNCA se sobrescriben durante el deploy:
+- api/config.php - Credenciales de base de datos
+- api/db_config.php - Configuración de conexión
+
+## Archivos de Configuración (No versionados)
+
+Estos archivos deben existir en el servidor pero NO en GitHub:
+- /home/wwimpo/deploy_config.php - Token de deploy
+
+## Rollback (Revertir Cambios)
+
+Si algo falla en producción, usar git revert y luego hacer deploy nuevamente.
+
+## GitHub
+
+- Repositorio: https://github.com/jpchs1/Imporlan
+- Branch principal: main

--- a/api/deploy.php
+++ b/api/deploy.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * Deploy Endpoint - Imporlan
+ * 
+ * Endpoint web para desplegar cambios desde GitHub.
+ * PROTEGIDO por token de seguridad.
+ * 
+ * Configuración:
+ * - El token debe estar en /home/wwimpo/deploy_config.php
+ * - O como variable de entorno DEPLOY_TOKEN
+ * 
+ * Uso:
+ * - Deploy a TEST: /api/deploy.php?env=test&token=TOKEN
+ * - Deploy a PROD: /api/deploy.php?env=prod&token=TOKEN&confirm=yes
+ * 
+ * @version 1.0
+ */
+
+// Cargar token desde archivo de configuración (no versionado)
+$configFile = '/home/wwimpo/deploy_config.php';
+if (file_exists($configFile)) {
+    require_once $configFile;
+}
+
+// Token de seguridad (debe estar definido en deploy_config.php)
+if (!defined('DEPLOY_TOKEN')) {
+    http_response_code(500);
+    die(json_encode(['success' => false, 'error' => 'Deploy token not configured']));
+}
+
+// Configuración del repositorio
+define('REPO_URL', 'https://github.com/jpchs1/Imporlan.git');
+define('BRANCH', 'main');
+
+// Rutas
+define('PATH_TEST', '/home/wwimpo/public_html/test');
+define('PATH_PROD', '/home/wwimpo/public_html');
+
+// Archivos protegidos (no se sobrescriben)
+$protectedFiles = [
+    'api/config.php',
+    'api/db_config.php'
+];
+
+header('Content-Type: application/json; charset=utf-8');
+
+// Verificar token
+$token = $_GET['token'] ?? '';
+if ($token !== DEPLOY_TOKEN) {
+    http_response_code(403);
+    die(json_encode(['success' => false, 'error' => 'Invalid token']));
+}
+
+// Verificar ambiente
+$env = $_GET['env'] ?? '';
+if (!in_array($env, ['test', 'prod'])) {
+    http_response_code(400);
+    die(json_encode([
+        'success' => false, 
+        'error' => 'Invalid environment',
+        'usage' => [
+            'test' => '?env=test&token=TOKEN',
+            'prod' => '?env=prod&token=TOKEN&confirm=yes'
+        ]
+    ]));
+}
+
+// Producción requiere confirmación
+if ($env === 'prod' && ($_GET['confirm'] ?? '') !== 'yes') {
+    http_response_code(400);
+    die(json_encode([
+        'success' => false,
+        'error' => 'Production requires explicit confirmation',
+        'usage' => '?env=prod&token=TOKEN&confirm=yes',
+        'warning' => 'This will update the LIVE site'
+    ]));
+}
+
+$targetPath = ($env === 'test') ? PATH_TEST : PATH_PROD;
+$tempPath = '/home/wwimpo/deploy_temp_' . time();
+$log = [];
+
+try {
+    $log[] = ['step' => 'init', 'message' => 'Starting deploy to ' . strtoupper($env)];
+    
+    if (!is_dir($tempPath)) {
+        mkdir($tempPath, 0755, true);
+    }
+    
+    $log[] = ['step' => 'clone', 'message' => 'Cloning from GitHub...'];
+    $cloneCmd = "cd " . escapeshellarg($tempPath) . " && git clone --depth 1 --branch " . BRANCH . " " . REPO_URL . " . 2>&1";
+    $cloneOutput = shell_exec($cloneCmd);
+    
+    if (!file_exists("$tempPath/index.html")) {
+        throw new Exception("Clone failed: " . $cloneOutput);
+    }
+    
+    $commitHash = trim(shell_exec("cd " . escapeshellarg($tempPath) . " && git rev-parse --short HEAD 2>&1"));
+    $commitMsg = trim(shell_exec("cd " . escapeshellarg($tempPath) . " && git log -1 --format='%s' 2>&1"));
+    $log[] = ['step' => 'commit', 'hash' => $commitHash, 'message' => $commitMsg];
+    
+    $backups = [];
+    foreach ($protectedFiles as $file) {
+        $fullPath = "$targetPath/$file";
+        if (file_exists($fullPath)) {
+            $backups[$file] = file_get_contents($fullPath);
+        }
+    }
+    $log[] = ['step' => 'backup', 'files' => array_keys($backups)];
+    
+    $excludes = "--exclude='.git' --exclude='api/config.php' --exclude='api/db_config.php'";
+    if ($env === 'prod') {
+        $excludes .= " --exclude='test' --exclude='panel-test'";
+    }
+    
+    $rsyncCmd = "rsync -av --delete $excludes " . escapeshellarg($tempPath) . "/ " . escapeshellarg($targetPath) . "/ 2>&1";
+    shell_exec($rsyncCmd);
+    $log[] = ['step' => 'sync', 'message' => 'Files synchronized'];
+    
+    foreach ($backups as $file => $content) {
+        $fullPath = "$targetPath/$file";
+        $dir = dirname($fullPath);
+        if (!is_dir($dir)) {
+            mkdir($dir, 0755, true);
+        }
+        file_put_contents($fullPath, $content);
+    }
+    $log[] = ['step' => 'restore', 'message' => 'Sensitive files restored'];
+    
+    shell_exec("rm -rf " . escapeshellarg($tempPath));
+    
+    $historyFile = '/home/wwimpo/deploy_history.json';
+    $history = file_exists($historyFile) ? json_decode(file_get_contents($historyFile), true) : [];
+    $history[] = [
+        'timestamp' => date('Y-m-d H:i:s'),
+        'environment' => $env,
+        'commit' => $commitHash,
+        'message' => $commitMsg,
+        'ip' => $_SERVER['REMOTE_ADDR'] ?? 'cli'
+    ];
+    $history = array_slice($history, -100);
+    file_put_contents($historyFile, json_encode($history, JSON_PRETTY_PRINT));
+    
+    echo json_encode([
+        'success' => true,
+        'environment' => $env,
+        'commit' => ['hash' => $commitHash, 'message' => $commitMsg],
+        'timestamp' => date('Y-m-d H:i:s'),
+        'log' => $log
+    ], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
+    
+} catch (Exception $e) {
+    if (is_dir($tempPath)) {
+        shell_exec("rm -rf " . escapeshellarg($tempPath));
+    }
+    
+    http_response_code(500);
+    echo json_encode([
+        'success' => false,
+        'error' => $e->getMessage(),
+        'log' => $log
+    ], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
+}


### PR DESCRIPTION
## Agregar script de deploy y documentación del flujo de trabajo

### Archivos agregados:
- `api/deploy.php`: Script de deploy automatizado desde GitHub
- `WORKFLOW.md`: Documentación completa del flujo de trabajo

### Características:
- Deploy a TEST: `/api/deploy.php?env=test&token=TOKEN`
- Deploy a PRODUCCIÓN: `/api/deploy.php?env=prod&token=TOKEN&confirm=yes`
- Token almacenado en archivo separado (no en repo)
- Backup automático de archivos sensibles
- Historial de deploys

---
Link to Devin run: https://app.devin.ai/sessions/c8b5ff53aff8455f8228772e740842d4
Requested by: Juan Pablo (jpchs1@gmail.com) @jpchs1