### PR TITLE
Replace PayPal redirect with Smart Buttons guest checkout

### DIFF
--- a/pago/index.html
+++ b/pago/index.html
@@ -843,7 +843,6 @@
                 await payWithMercadoPago(data);
             } else if (selectedMethod === 'paypal') {
                 /* PayPal is handled by Smart Buttons inline, not this flow */
-                setLoading(false);
                 return;
             } else if (selectedMethod === 'transfer') {
                 handleTransfer(data);


### PR DESCRIPTION
## Summary
- Replace PayPal redirect-based flow with inline Smart Buttons (matching tourevo.cl/pago/)
- When user selects PayPal, standard pay button hides and PayPal SDK renders two buttons: "PayPal" + "Debit or Credit Card" (guest checkout sin login)
- Add loading spinner while PayPal SDK loads
- Update PayPal tile label to "Tarjeta / PayPal"
- WebPay, MercadoPago and Transferencia unchanged

## Changes
- **CSS**: Added `#paypal-button-container`, `.paypal-loading`, `.paypal-spinner` styles
- **HTML**: Added `<div id="paypal-button-container">` before pay button
- **JS**: Replaced `payWithPayPal()` with `renderPayPalButtons()`, `loadPayPalSDKForButtons()`, `doRenderPayPalButtons()`
- **JS**: Updated `selectMethod()` to show/hide PayPal container and hide standard button
- **JS**: Updated `processPayment()` PayPal case to no-op (handled by Smart Buttons)

## Test plan
- [ ] Select PayPal → verify two buttons render (PayPal gold + Debit/Credit Card black)
- [ ] Click "Debit or Credit Card" → verify guest checkout without PayPal login
- [ ] Click PayPal button → verify PayPal flow works
- [ ] Cancel payment → verify cancel message shows
- [ ] Switch to WebPay/MercadoPago → verify PayPal buttons hide and standard button returns
- [ ] Verify WebPay and MercadoPago flows remain unchanged

https://claude.ai/code/session_01WDcKQgKshSA6w8ZGBzwFey
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jpchs1/imporlan/pull/382" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
