### PR TITLE
fix: auto-migrate retorna datos reales post-migracion

### DIFF
--- a/api/config_api.php
+++ b/api/config_api.php
@@ -173,7 +173,17 @@ function plansList() {
         echo json_encode(['success' => true, 'plans' => $plans, 'total' => count($plans)]);
     } catch (PDOException $e) {
         if (strpos($e->getMessage(), "doesn't exist") !== false) {
+            ob_start();
             configMigrate();
+            ob_end_clean();
+            try {
+                $stmt = $pdo->query("SELECT * FROM search_plans ORDER BY sort_order ASC, id ASC");
+                $plans = $stmt->fetchAll(PDO::FETCH_ASSOC);
+                echo json_encode(['success' => true, 'plans' => $plans, 'total' => count($plans)]);
+            } catch (PDOException $e2) {
+                http_response_code(500);
+                echo json_encode(['error' => 'Migration failed: ' . $e2->getMessage()]);
+            }
             return;
         }
         http_response_code(500);
@@ -257,7 +267,17 @@ function agentsList() {
         echo json_encode(['success' => true, 'agents' => $agents, 'total' => count($agents)]);
     } catch (PDOException $e) {
         if (strpos($e->getMessage(), "doesn't exist") !== false) {
+            ob_start();
             configMigrate();
+            ob_end_clean();
+            try {
+                $stmt = $pdo->query("SELECT * FROM agents ORDER BY id ASC");
+                $agents = $stmt->fetchAll(PDO::FETCH_ASSOC);
+                echo json_encode(['success' => true, 'agents' => $agents, 'total' => count($agents)]);
+            } catch (PDOException $e2) {
+                http_response_code(500);
+                echo json_encode(['error' => 'Migration failed: ' . $e2->getMessage()]);
+            }
             return;
         }
         http_response_code(500);
@@ -341,7 +361,21 @@ function pricingGet() {
         echo json_encode(['success' => true, 'pricing' => $result]);
     } catch (PDOException $e) {
         if (strpos($e->getMessage(), "doesn't exist") !== false) {
+            ob_start();
             configMigrate();
+            ob_end_clean();
+            try {
+                $stmt = $pdo->query("SELECT * FROM pricing_config ORDER BY id ASC");
+                $configs = $stmt->fetchAll(PDO::FETCH_ASSOC);
+                $result = [];
+                foreach ($configs as $c) {
+                    $result[$c['config_key']] = ['value' => $c['config_value'], 'description' => $c['description'], 'id' => $c['id']];
+                }
+                echo json_encode(['success' => true, 'pricing' => $result]);
+            } catch (PDOException $e2) {
+                http_response_code(500);
+                echo json_encode(['error' => 'Migration failed: ' . $e2->getMessage()]);
+            }
             return;
         }
         http_response_code(500);


### PR DESCRIPTION
## Summary
- Después de auto-migrar tablas, re-consulta y devuelve los datos reales (planes/agentes/precios) en vez del mensaje de migración
- Esto corrige el skeleton loading infinito en Configuración y el error en Planes

https://claude.ai/code/session_01YPE71D7wSiJn2ypPnMeeyd
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jpchs1/imporlan/pull/408" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
