### PR TITLE
fix: hide React demo documents completely

### DIFF
--- a/panel-test/assets/documents-enhancer.js
+++ b/panel-test/assets/documents-enhancer.js
@@ -17,9 +17,23 @@
     return "";
   }
 
+  // Inject CSS immediately to hide React documents content before it renders
+  var hideStyle = document.createElement("style");
+  hideStyle.id = "docs-hide-react";
+  hideStyle.textContent = "";
+  document.head.appendChild(hideStyle);
+
   function isDocumentsPage() {
     var h1 = document.querySelector("main h1");
-    return h1 && h1.textContent.trim() === "Documentos";
+    var isDoc = h1 && h1.textContent.trim() === "Documentos";
+    // Immediately hide React content when on documents page
+    var st = document.getElementById("docs-hide-react");
+    if (st) {
+      st.textContent = isDoc
+        ? "main > *:not(#docs-enhancer) { display: none !important; }"
+        : "";
+    }
+    return isDoc;
   }
 
   function escHtml(t) { if (!t) return ""; var d = document.createElement("div"); d.textContent = t; return d.innerHTML; }

--- a/panel/assets/documents-enhancer.js
+++ b/panel/assets/documents-enhancer.js
@@ -17,9 +17,23 @@
     return "";
   }
 
+  // Inject CSS immediately to hide React documents content before it renders
+  var hideStyle = document.createElement("style");
+  hideStyle.id = "docs-hide-react";
+  hideStyle.textContent = "";
+  document.head.appendChild(hideStyle);
+
   function isDocumentsPage() {
     var h1 = document.querySelector("main h1");
-    return h1 && h1.textContent.trim() === "Documentos";
+    var isDoc = h1 && h1.textContent.trim() === "Documentos";
+    // Immediately hide React content when on documents page
+    var st = document.getElementById("docs-hide-react");
+    if (st) {
+      st.textContent = isDoc
+        ? "main > *:not(#docs-enhancer) { display: none !important; }"
+        : "";
+    }
+    return isDoc;
   }
 
   function escHtml(t) { if (!t) return ""; var d = document.createElement("div"); d.textContent = t; return d.innerHTML; }


### PR DESCRIPTION
Force hides React demo documents (4 Aprobados, 2 Pendientes) with injected CSS that activates immediately when on Documents page.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jpchs1/imporlan/pull/413" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
