### PR TITLE
fix: 2FA token bypass, LIMIT/OFFSET compat, IDOR revert

### DIFF
--- a/api/admin_api.php
+++ b/api/admin_api.php
@@ -68,7 +68,9 @@ function base64UrlDecode($data) {
 
 function createJWT($payload) {
     $header = json_encode(['alg' => 'HS256', 'typ' => 'JWT']);
-    $payload['exp'] = time() + (7 * 24 * 60 * 60);
+    if (!isset($payload['exp'])) {
+        $payload['exp'] = time() + (7 * 24 * 60 * 60);
+    }
     $payload['iat'] = time();
     
     $base64Header = base64UrlEncode($header);
@@ -117,12 +119,19 @@ function requireAuth() {
         exit();
     }
     
+    // Reject 2FA pending tokens - they should only be used for /auth/verify-2fa
+    if (($payload['purpose'] ?? null) === '2fa_pending') {
+        http_response_code(401);
+        echo json_encode(['detail' => 'Token de 2FA no es valido para esta operacion']);
+        exit();
+    }
+
     if (!in_array($payload['role'], ['admin', 'support', 'agent'])) {
         http_response_code(403);
         echo json_encode(['detail' => 'Acceso denegado']);
         exit();
     }
-    
+
     return $payload;
 }
 

--- a/api/audit_api.php
+++ b/api/audit_api.php
@@ -156,14 +156,14 @@ function auditList() {
         $countStmt = $pdo->prepare("SELECT COUNT(*) as total FROM audit_log $whereClause");
         $countStmt->execute($params);
         $total = intval($countStmt->fetch(PDO::FETCH_ASSOC)['total']);
+        $limit = intval($limit);
+        $offset = intval($offset);
         $stmt = $pdo->prepare("
             SELECT * FROM audit_log
             $whereClause
             ORDER BY created_at DESC
-            LIMIT ? OFFSET ?
+            LIMIT $limit OFFSET $offset
         ");
-        $params[] = $limit;
-        $params[] = $offset;
         $stmt->execute($params);
         $logs = $stmt->fetchAll(PDO::FETCH_ASSOC);
         echo json_encode([

--- a/api/auth_helper.php
+++ b/api/auth_helper.php
@@ -81,6 +81,12 @@ function requireAdminAuthShared($allowedRoles = ['admin', 'support']) {
         exit();
     }
 
+    if (($payload['purpose'] ?? null) === '2fa_pending') {
+        http_response_code(401);
+        echo json_encode(['error' => 'Token de 2FA no es valido para esta operacion']);
+        exit();
+    }
+
     if (!isset($payload['role']) || !in_array($payload['role'], $allowedRoles)) {
         http_response_code(403);
         echo json_encode(['error' => 'Acceso denegado']);

--- a/api/cron/rotate_featured_vessels.php
+++ b/api/cron/rotate_featured_vessels.php
@@ -50,25 +50,24 @@ try {
     }
 
     if ($rotatedCount > 0) {
-        $stmt = $pdo->prepare("
+        $rotatedCount = intval($rotatedCount);
+        $pdo->exec("
             UPDATE vessels SET status='active', is_featured=1
             WHERE type='auto' AND status='scheduled'
             ORDER BY created_at ASC
-            LIMIT ?
+            LIMIT $rotatedCount
         ");
-        $stmt->execute([intval($rotatedCount)]);
     }
 
     $activeCount = $pdo->query("SELECT COUNT(*) FROM vessels WHERE is_featured=1 AND status='active'")->fetchColumn();
     if ($activeCount < 3) {
         $needed = intval(3 - $activeCount);
-        $stmt = $pdo->prepare("
+        $pdo->exec("
             UPDATE vessels SET is_featured=1, status='active'
             WHERE type='auto' AND status='scheduled' AND is_featured=0
             ORDER BY created_at ASC
-            LIMIT ?
+            LIMIT $needed
         ");
-        $stmt->execute([$needed]);
     }
 
     $navigatingCount = $pdo->query("

--- a/api/orders_api.php
+++ b/api/orders_api.php
@@ -40,12 +40,10 @@ if (basename($_SERVER['SCRIPT_FILENAME']) === basename(__FILE__)) {
             runMigration();
             break;
         case 'user_list':
-            $userPayload = requireUserAuthShared();
-            userListOrders($userPayload);
+            userListOrders();
             break;
         case 'user_detail':
-            $userPayload = requireUserAuthShared();
-            userGetOrderDetail($userPayload);
+            userGetOrderDetail();
             break;
         case 'admin_list':
             requireAdminAuth();

--- a/api/tracking_api.php
+++ b/api/tracking_api.php
@@ -667,23 +667,22 @@ function adminRotateFeatured() {
         }
 
         if ($rotated > 0) {
-            $stmt = $pdo->prepare("
+            $rotated = intval($rotated);
+            $pdo->exec("
                 UPDATE vessels SET status='active'
                 WHERE type='auto' AND status='scheduled'
-                LIMIT ?
+                LIMIT $rotated
             ");
-            $stmt->execute([intval($rotated)]);
         }
 
         $activeCount = $pdo->query("SELECT COUNT(*) FROM vessels WHERE is_featured=1 AND status='active'")->fetchColumn();
         if ($activeCount < 3) {
             $needed = intval(3 - $activeCount);
-            $stmt = $pdo->prepare("
+            $pdo->exec("
                 UPDATE vessels SET is_featured=1, status='active'
                 WHERE type='auto' AND status='scheduled' AND is_featured=0
-                LIMIT ?
+                LIMIT $needed
             ");
-            $stmt->execute([$needed]);
         }
 
         echo json_encode(['success' => true, 'rotated' => $rotated, 'active_featured' => intval($activeCount)]);

--- a/test/api/admin_api.php
+++ b/test/api/admin_api.php
@@ -69,7 +69,9 @@ function base64UrlDecode($data) {
 
 function createJWT($payload) {
     $header = json_encode(['alg' => 'HS256', 'typ' => 'JWT']);
-    $payload['exp'] = time() + (7 * 24 * 60 * 60);
+    if (!isset($payload['exp'])) {
+        $payload['exp'] = time() + (7 * 24 * 60 * 60);
+    }
     $payload['iat'] = time();
     
     $base64Header = base64UrlEncode($header);
@@ -118,12 +120,18 @@ function requireAuth() {
         exit();
     }
     
+    if (($payload['purpose'] ?? null) === '2fa_pending') {
+        http_response_code(401);
+        echo json_encode(['detail' => 'Token de 2FA no es valido para esta operacion']);
+        exit();
+    }
+
     if (!in_array($payload['role'], ['admin', 'support', 'agent'])) {
         http_response_code(403);
         echo json_encode(['detail' => 'Acceso denegado']);
         exit();
     }
-    
+
     return $payload;
 }
 

--- a/test/api/orders_api.php
+++ b/test/api/orders_api.php
@@ -41,12 +41,10 @@ if (basename($_SERVER['SCRIPT_FILENAME']) === basename(__FILE__)) {
             runMigration();
             break;
         case 'user_list':
-            $userPayload = requireUserAuthShared();
-            userListOrders($userPayload);
+            userListOrders();
             break;
         case 'user_detail':
-            $userPayload = requireUserAuthShared();
-            userGetOrderDetail($userPayload);
+            userGetOrderDetail();
             break;
         case 'admin_list':
             requireAdminAuth();


### PR DESCRIPTION
Addresses review findings from Devin and Codex on PR #440:
- Fix 2FA token bypass (temp token was valid for 7 days as full admin token)
- Fix LIMIT/OFFSET PDO compatibility
- Revert IDOR auth requirement on user order endpoints (breaks panel)

https://claude.ai/code/session_01KaGTEFH5vRCUSb8BtZMxgd
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jpchs1/imporlan/pull/442" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
