### PR TITLE
fix: revert enhancer to original DOM detection, keep hashchange fix

### DIFF
--- a/admin/assets/admin-data-enhancer.js
+++ b/admin/assets/admin-data-enhancer.js
@@ -62,27 +62,7 @@
   var checkTimer = null;
   var configActive = false;
 
-  var hashToSection = {
-    "": "Dashboard",
-    "dashboard": "Dashboard",
-    "usuarios": "Usuarios",
-    "solicitudes": "Solicitudes",
-    "planes": "Planes",
-    "pagos": "Pagos",
-    "contenido": "Contenido",
-    "auditoria": "Auditoria",
-    "inspecciones": "Inspecciones",
-    "tracking": "Tracking",
-    "expedientes": "Expedientes",
-    "configuracion": "Configuracion"
-  };
-
   function getSection() {
-    var hash = (window.location.hash || "").replace("#", "").split("?")[0].split("/")[0].toLowerCase();
-    if (hash && hashToSection[hash]) {
-      configActive = (hash === "configuracion");
-      return hashToSection[hash];
-    }
     if (configActive) return "Configuracion";
     var h = document.querySelector("main h1");
     return h ? h.textContent.trim() : "";
@@ -1657,7 +1637,6 @@
     btn.addEventListener("mouseenter", function() { this.style.background = "rgba(8,145,178,.08)"; this.style.color = "#0891b2"; });
     btn.addEventListener("mouseleave", function() { if (!this.classList.contains("cfg-active")) { this.style.background = "transparent"; this.style.color = "#94a3b8"; } });
     btn.addEventListener("click", function() {
-      window.location.hash = "#configuracion";
       configActive = true;
       var main = document.querySelector("main");
       if (main) {
@@ -1812,14 +1791,8 @@
     return true;
   }
 
-  var externalSections = ["Inspecciones", "Tracking", "Expedientes"];
-
   function enhance(section) {
     if (enhanced[section]) return;
-    if (externalSections.indexOf(section) !== -1) {
-      enhanced[section] = true;
-      return;
-    }
     addSkeletonStyles();
     var ok = false;
     try {
@@ -1832,7 +1805,6 @@
         case "Contenido": ok = enhanceContenido(); break;
         case "Auditoria": ok = true; break;
         case "Configuracion": ok = enhanceConfiguracion(); break;
-        default: ok = true; break;
       }
     } catch (e) { console.warn("Admin enhancer error:", e); }
     if (ok) enhanced[section] = true;

--- a/panel-test/admin/assets/admin-data-enhancer.js
+++ b/panel-test/admin/assets/admin-data-enhancer.js
@@ -62,27 +62,7 @@
   var checkTimer = null;
   var configActive = false;
 
-  var hashToSection = {
-    "": "Dashboard",
-    "dashboard": "Dashboard",
-    "usuarios": "Usuarios",
-    "solicitudes": "Solicitudes",
-    "planes": "Planes",
-    "pagos": "Pagos",
-    "contenido": "Contenido",
-    "auditoria": "Auditoria",
-    "inspecciones": "Inspecciones",
-    "tracking": "Tracking",
-    "expedientes": "Expedientes",
-    "configuracion": "Configuracion"
-  };
-
   function getSection() {
-    var hash = (window.location.hash || "").replace("#", "").split("?")[0].split("/")[0].toLowerCase();
-    if (hash && hashToSection[hash]) {
-      configActive = (hash === "configuracion");
-      return hashToSection[hash];
-    }
     if (configActive) return "Configuracion";
     var h = document.querySelector("main h1");
     return h ? h.textContent.trim() : "";
@@ -1657,7 +1637,6 @@
     btn.addEventListener("mouseenter", function() { this.style.background = "rgba(8,145,178,.08)"; this.style.color = "#0891b2"; });
     btn.addEventListener("mouseleave", function() { if (!this.classList.contains("cfg-active")) { this.style.background = "transparent"; this.style.color = "#94a3b8"; } });
     btn.addEventListener("click", function() {
-      window.location.hash = "#configuracion";
       configActive = true;
       var main = document.querySelector("main");
       if (main) {
@@ -1812,14 +1791,8 @@
     return true;
   }
 
-  var externalSections = ["Inspecciones", "Tracking", "Expedientes"];
-
   function enhance(section) {
     if (enhanced[section]) return;
-    if (externalSections.indexOf(section) !== -1) {
-      enhanced[section] = true;
-      return;
-    }
     addSkeletonStyles();
     var ok = false;
     try {
@@ -1832,7 +1805,6 @@
         case "Contenido": ok = enhanceContenido(); break;
         case "Auditoria": ok = true; break;
         case "Configuracion": ok = enhanceConfiguracion(); break;
-        default: ok = true; break;
       }
     } catch (e) { console.warn("Admin enhancer error:", e); }
     if (ok) enhanced[section] = true;

--- a/panel/admin/assets/admin-data-enhancer.js
+++ b/panel/admin/assets/admin-data-enhancer.js
@@ -62,30 +62,7 @@
   var checkTimer = null;
   var configActive = false;
 
-  // Map hash routes to section names used by the enhancer
-  var hashToSection = {
-    "": "Dashboard",
-    "dashboard": "Dashboard",
-    "usuarios": "Usuarios",
-    "solicitudes": "Solicitudes",
-    "planes": "Planes",
-    "pagos": "Pagos",
-    "contenido": "Contenido",
-    "auditoria": "Auditoria",
-    "inspecciones": "Inspecciones",
-    "tracking": "Tracking",
-    "expedientes": "Expedientes",
-    "configuracion": "Configuracion"
-  };
-
   function getSection() {
-    // Primary: use hash route as source of truth
-    var hash = (window.location.hash || "").replace("#", "").split("?")[0].split("/")[0].toLowerCase();
-    if (hash && hashToSection[hash]) {
-      configActive = (hash === "configuracion");
-      return hashToSection[hash];
-    }
-    // Fallback for unknown hashes: read DOM
     if (configActive) return "Configuracion";
     var h = document.querySelector("main h1");
     return h ? h.textContent.trim() : "";
@@ -1660,7 +1637,6 @@
     btn.addEventListener("mouseenter", function() { this.style.background = "rgba(8,145,178,.08)"; this.style.color = "#0891b2"; });
     btn.addEventListener("mouseleave", function() { if (!this.classList.contains("cfg-active")) { this.style.background = "transparent"; this.style.color = "#94a3b8"; } });
     btn.addEventListener("click", function() {
-      window.location.hash = "#configuracion";
       configActive = true;
       var main = document.querySelector("main");
       if (main) {
@@ -1815,16 +1791,8 @@
     return true;
   }
 
-  // Sections managed by other scripts - enhancer should not touch them
-  var externalSections = ["Inspecciones", "Tracking", "Expedientes"];
-
   function enhance(section) {
     if (enhanced[section]) return;
-    // Don't interfere with sections managed by other scripts
-    if (externalSections.indexOf(section) !== -1) {
-      enhanced[section] = true;
-      return;
-    }
     addSkeletonStyles();
     var ok = false;
     try {
@@ -1837,7 +1805,6 @@
         case "Contenido": ok = enhanceContenido(); break;
         case "Auditoria": ok = true; break;
         case "Configuracion": ok = enhanceConfiguracion(); break;
-        default: ok = true; break;
       }
     } catch (e) { console.warn("Admin enhancer error:", e); }
     if (ok) enhanced[section] = true;
@@ -1848,12 +1815,7 @@
     var s = getSection();
     if (!s) return;
     if (s !== lastSection) {
-      if (externalSections.indexOf(s) === -1) {
-        cleanupEnhancer();
-      } else {
-        // External section: only remove enhancer-injected elements, don't touch anything else
-        cleanupEnhancer();
-      }
+      cleanupEnhancer();
       lastSection = s;
       enhanced = {};
     }


### PR DESCRIPTION
Reverts getSection() to original DOM-based detection. Only keeps the hashchange listener to reset configActive flag.

https://claude.ai/code/session_01KaGTEFH5vRCUSb8BtZMxgd
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jpchs1/imporlan/pull/444" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
