### PR TITLE
revert: restore admin-data-enhancer.js to working version

### DIFF
--- a/admin/assets/admin-data-enhancer.js
+++ b/admin/assets/admin-data-enhancer.js
@@ -1843,14 +1843,6 @@
         enhanced = {};
       }
     }, true);
-    window.addEventListener("hashchange", function() {
-      if (configActive) {
-        configActive = false;
-        cleanupEnhancer();
-        lastSection = "";
-        enhanced = {};
-      }
-    });
     new MutationObserver(debouncedCheck).observe(document.body, { childList: true, subtree: true });
     setInterval(function() { injectConfigSidebar(); check(); }, 500);
     check();

--- a/panel-test/admin/assets/admin-data-enhancer.js
+++ b/panel-test/admin/assets/admin-data-enhancer.js
@@ -1843,14 +1843,6 @@
         enhanced = {};
       }
     }, true);
-    window.addEventListener("hashchange", function() {
-      if (configActive) {
-        configActive = false;
-        cleanupEnhancer();
-        lastSection = "";
-        enhanced = {};
-      }
-    });
     new MutationObserver(debouncedCheck).observe(document.body, { childList: true, subtree: true });
     setInterval(function() { injectConfigSidebar(); check(); }, 500);
     check();

--- a/panel/admin/assets/admin-data-enhancer.js
+++ b/panel/admin/assets/admin-data-enhancer.js
@@ -1843,14 +1843,6 @@
         enhanced = {};
       }
     }, true);
-    window.addEventListener("hashchange", function() {
-      if (configActive) {
-        configActive = false;
-        cleanupEnhancer();
-        lastSection = "";
-        enhanced = {};
-      }
-    });
     new MutationObserver(debouncedCheck).observe(document.body, { childList: true, subtree: true });
     setInterval(function() { injectConfigSidebar(); check(); }, 500);
     check();


### PR DESCRIPTION
Restores admin-data-enhancer.js to the exact version from commit a1608bc - the last confirmed working version before any routing changes.

https://claude.ai/code/session_01KaGTEFH5vRCUSb8BtZMxgd
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jpchs1/imporlan/pull/445" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
