### PR TITLE
fix: reset enhancer state on sidebar click and hash change

### DIFF
--- a/admin/assets/admin-data-enhancer.js
+++ b/admin/assets/admin-data-enhancer.js
@@ -1843,6 +1843,25 @@
         enhanced = {};
       }
     }, true);
+    // Reset configActive when navigating away via hash change
+    window.addEventListener("hashchange", function() {
+      if (configActive) {
+        configActive = false;
+        cleanupEnhancer();
+        lastSection = "";
+        enhanced = {};
+      }
+    });
+    // Reset enhancer state when clicking any sidebar nav button
+    document.addEventListener("click", function(e) {
+      var btn = e.target.closest("aside nav ul button, aside nav ul a");
+      if (btn && btn.id !== "sidebar-config-admin") {
+        configActive = false;
+        cleanupEnhancer();
+        lastSection = "";
+        enhanced = {};
+      }
+    });
     new MutationObserver(debouncedCheck).observe(document.body, { childList: true, subtree: true });
     setInterval(function() { injectConfigSidebar(); check(); }, 500);
     check();

--- a/panel-test/admin/assets/admin-data-enhancer.js
+++ b/panel-test/admin/assets/admin-data-enhancer.js
@@ -1843,6 +1843,25 @@
         enhanced = {};
       }
     }, true);
+    // Reset configActive when navigating away via hash change
+    window.addEventListener("hashchange", function() {
+      if (configActive) {
+        configActive = false;
+        cleanupEnhancer();
+        lastSection = "";
+        enhanced = {};
+      }
+    });
+    // Reset enhancer state when clicking any sidebar nav button
+    document.addEventListener("click", function(e) {
+      var btn = e.target.closest("aside nav ul button, aside nav ul a");
+      if (btn && btn.id !== "sidebar-config-admin") {
+        configActive = false;
+        cleanupEnhancer();
+        lastSection = "";
+        enhanced = {};
+      }
+    });
     new MutationObserver(debouncedCheck).observe(document.body, { childList: true, subtree: true });
     setInterval(function() { injectConfigSidebar(); check(); }, 500);
     check();

--- a/panel/admin/assets/admin-data-enhancer.js
+++ b/panel/admin/assets/admin-data-enhancer.js
@@ -1843,6 +1843,25 @@
         enhanced = {};
       }
     }, true);
+    // Reset configActive when navigating away via hash change
+    window.addEventListener("hashchange", function() {
+      if (configActive) {
+        configActive = false;
+        cleanupEnhancer();
+        lastSection = "";
+        enhanced = {};
+      }
+    });
+    // Reset enhancer state when clicking any sidebar nav button
+    document.addEventListener("click", function(e) {
+      var btn = e.target.closest("aside nav ul button, aside nav ul a");
+      if (btn && btn.id !== "sidebar-config-admin") {
+        configActive = false;
+        cleanupEnhancer();
+        lastSection = "";
+        enhanced = {};
+      }
+    });
     new MutationObserver(debouncedCheck).observe(document.body, { childList: true, subtree: true });
     setInterval(function() { injectConfigSidebar(); check(); }, 500);
     check();


### PR DESCRIPTION
Minimal fix: adds hashchange + sidebar click listeners to reset enhancer state. No other changes to the working enhancer logic.

https://claude.ai/code/session_01KaGTEFH5vRCUSb8BtZMxgd
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jpchs1/imporlan/pull/446" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
