### PR TITLE
fix(deploy): evitar process substitution en limpieza de backups

### DIFF
--- a/deploy-prod.sh
+++ b/deploy-prod.sh
@@ -234,9 +234,12 @@ echo ""
 echo "[9/9] Cleaning old production backups (keeping last 5)..."
 for PREFIX in assets_backup api_backup panel_backup; do
   BACKUPS=()
-  while IFS= read -r -d '' entry; do
-    BACKUPS+=("$entry")
-  done < <(find "$BACKUP_DIR" -maxdepth 1 -type d -name "${PREFIX}_*" -print0 2>/dev/null | sort -z)
+  for entry in "$BACKUP_DIR"/${PREFIX}_*; do
+    [ -d "$entry" ] && BACKUPS+=("$entry")
+  done
+  if [ "${#BACKUPS[@]}" -gt 0 ]; then
+    IFS=$'\n' BACKUPS=($(printf '%s\n' "${BACKUPS[@]}" | sort)); unset IFS
+  fi
   COUNT=${#BACKUPS[@]}
   if [ "$COUNT" -gt 5 ]; then
     REMOVE=$((COUNT - 5))


### PR DESCRIPTION
## Resumen

- Elimina los warnings `/dev/fd/62: No such file or directory` que aparecían al final de cada `deploy-prod.sh` en Banahosting.
- Restaura la rotación automática de backups (antes quedaba rota, por eso se habían acumulado 7+ backups por tipo en vez del límite de 5).

## Causa

El bloque original usaba *process substitution* (`done < <(find ... -print0 | sort -z)`), que requiere `/dev/fd/` disponible. El shell de Banahosting no lo expone correctamente en este contexto, así que el array `BACKUPS` quedaba vacío y el `if "$COUNT" -gt 5` nunca se ejecutaba.

## Fix

Reemplazo por un glob simple + `sort` posterior. Los nombres de backup no tienen espacios (`assets_backup_YYYY-MM-DD_HHMM`), así que el split por newline es seguro.

## Test plan
- [ ] Correr `deploy-prod.sh` en Banahosting y verificar que **no** aparezcan los warnings `/dev/fd/62`.
- [ ] Después de 6+ deploys, verificar que solo queden los últimos 5 backups por tipo.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jpchs1/imporlan/pull/471" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
