### PR TITLE
Move Transparency section after Cotiza tu lancha

### DIFF
--- a/assets/transparencia-section.js
+++ b/assets/transparencia-section.js
@@ -298,6 +298,7 @@
     if (existing) existing.remove();
 
     var checkInterval = setInterval(function () {
+      var cotizarSection = document.getElementById('cotizar');
       var inspeccionSection = document.getElementById('inspeccion-precompra');
       var procesoSection = document.getElementById('proceso-compra');
       var serviciosSection = document.getElementById('servicios-importacion');
@@ -306,7 +307,10 @@
       var insertPoint = null;
       var parentNode = null;
 
-      if (inspeccionSection) {
+      if (cotizarSection) {
+        insertPoint = cotizarSection.nextSibling;
+        parentNode = cotizarSection.parentNode;
+      } else if (inspeccionSection) {
         insertPoint = inspeccionSection.nextSibling;
         parentNode = inspeccionSection.parentNode;
       } else if (procesoSection) {

--- a/index.html
+++ b/index.html
@@ -221,7 +221,7 @@
     <script src="/assets/marketplace-section.js?v=20260227b"></script>
     <script src="/assets/seo-pages-section.js?v=20260304b"></script>
     <script src="/assets/inspeccion-precompra-section.js?v=20260324"></script>
-    <script src="/assets/transparencia-section.js?v=20260427a"></script>
+    <script src="/assets/transparencia-section.js?v=20260427b"></script>
     <script src="/assets/image-optimizer.js?v=20260122"></script>
     <script src="/assets/center-cards.js?v=20260122"></script>
     <script src="/assets/ranking-preview-section.js?v=20260330"></script>


### PR DESCRIPTION
## Summary

Moves the Transparency Policy section to appear right after the "Cotiza tu lancha" section (`#cotizar`) on the home page, instead of after the pre-purchase inspection section. Falls back to previous insertion points if `#cotizar` is not found. Bumps cache-busting version on the script tag.

## Files changed
- `assets/transparencia-section.js` (insertion logic)
- `index.html` (cache version `v=20260427b`)

## Test plan
- [ ] Verify the section now appears immediately after the Cotizador section on www.imporlan.cl after deploy and hard refresh

https://claude.ai/code/session_01Y1DzYmKfKyrSdLZQDiHTmJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1DzYmKfKyrSdLZQDiHTmJ)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jpchs1/imporlan/pull/478" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
