### PR TITLE
Fix admin password recovery email + email/payment fixes

### DIFF
--- a/admin/assets/login-enhancer.js
+++ b/admin/assets/login-enhancer.js
@@ -131,7 +131,7 @@
         '</div>' +
         '<p style="margin:0 0 20px;font-size:14px;color:#64748b;line-height:1.5">' +
           'Ingresa tu email de inicio de sesion (<strong>admin@imporlan.cl</strong>).<br>' +
-          'Se enviara un enlace de recuperacion a <strong>contacto@imporlan.cl</strong>.' +
+          'El enlace de recuperacion se enviara al buzon del administrador: <strong>contacto@imporlan.cl</strong>.' +
         '</p>' +
         '<label style="display:block;margin-bottom:6px;font-size:13px;font-weight:600;color:#475569">Email de inicio de sesion</label>' +
         '<input id="admin-forgot-email" type="email" value="admin@imporlan.cl" ' +
@@ -182,12 +182,16 @@
         msgEl.style.display = "block";
         if (data.success) {
           msgEl.style.color = "#10b981";
-          msgEl.textContent = data.message || "Se ha enviado un enlace de recuperacion a contacto@imporlan.cl.";
+          msgEl.textContent = data.message || "Se envio un enlace de recuperacion al buzon del administrador (contacto@imporlan.cl). Revisa la bandeja de entrada y la carpeta de spam.";
           sendBtn.textContent = "Enlace Enviado";
           sendBtn.style.background = "#10b981";
         } else {
           msgEl.style.color = "#ef4444";
-          msgEl.textContent = data.error || "No se pudo procesar la solicitud.";
+          var errorText = data.error || "No se pudo procesar la solicitud.";
+          if (data.detail) {
+            errorText += " (" + data.detail + ")";
+          }
+          msgEl.textContent = errorText;
           sendBtn.disabled = false;
           sendBtn.textContent = "Enviar Enlace de Recuperacion";
           sendBtn.style.opacity = "1";

--- a/api/admin_forgot_password.php
+++ b/api/admin_forgot_password.php
@@ -1,8 +1,12 @@
 <?php
 /**
  * Admin Forgot Password - Imporlan Admin Panel
+ *
  * Generates a secure reset token, stores it on the server, and emails
- * a reset link to contacto@imporlan.cl so the admin can set a new password.
+ * a reset link to contacto@imporlan.cl (the admin's real mailbox) using
+ * the shared EmailService. EmailService loads its SMTP credentials from
+ * /home/wwimpo/smtp_config.php in production, which is the only SMTP
+ * configuration that is actually authorised against mail.imporlan.cl.
  */
 require_once __DIR__ . '/cors_helper.php';
 setCorsHeadersSecure();
@@ -28,58 +32,43 @@ if (!$email || strpos($email, '@') === false) {
     exit();
 }
 
-// Only allow admin email
 if ($email !== 'admin@imporlan.cl') {
     http_response_code(400);
     echo json_encode(['error' => 'Este formulario es solo para el administrador.']);
     exit();
 }
 
-// Generate secure token
 $token = bin2hex(random_bytes(32));
 $expiry = time() + 3600; // 1 hour
 
-// Store token in a file (one token at a time for admin)
 $tokenDir = __DIR__ . '/../.admin_reset_tokens';
 if (!is_dir($tokenDir)) {
     mkdir($tokenDir, 0700, true);
 }
-// Write .htaccess to protect the directory
 $htaccess = $tokenDir . '/.htaccess';
 if (!file_exists($htaccess)) {
     file_put_contents($htaccess, "Deny from all\n");
 }
 $tokenFile = $tokenDir . '/token.json';
 file_put_contents($tokenFile, json_encode([
-    'token' => hash('sha256', $token),
-    'email' => $email,
-    'expiry' => $expiry,
-    'ip' => isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : 'unknown',
+    'token'   => hash('sha256', $token),
+    'email'   => $email,
+    'expiry'  => $expiry,
+    'ip'      => isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : 'unknown',
     'created' => date('Y-m-d H:i:s')
 ]));
 
-// Detect base URL
-$isTest = false;
-if (isset($_SERVER['REQUEST_URI'])) {
-    $isTest = strpos($_SERVER['REQUEST_URI'], '/test/') !== false;
-}
-$scheme = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https' : 'http';
-$host = isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : 'www.imporlan.cl';
+$isTest  = isset($_SERVER['REQUEST_URI']) && strpos($_SERVER['REQUEST_URI'], '/test/') !== false;
+$scheme  = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https' : 'http';
+$host    = isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : 'www.imporlan.cl';
 $basePath = $isTest ? '/test/api' : '/api';
 $resetUrl = $scheme . '://' . $host . $basePath . '/admin_reset_password.php?token=' . $token;
 
-// SMTP configuration
-$smtpHost = 'mail.imporlan.cl';
-$smtpPort = 465;
-$smtpUser = 'contacto@imporlan.cl';
-$smtpPass = '^IBn?P-Z5@#_';
+$to      = 'contacto@imporlan.cl';
+$date    = date('d/m/Y H:i:s');
+$subject = ($isTest ? '[TEST] ' : '') . 'Restablecer contrasena - Admin Panel Imporlan';
 
-$to = 'contacto@imporlan.cl';
-$date = date('d/m/Y H:i:s');
-
-$subject = 'Restablecer contrasena - Admin Panel Imporlan';
-
-$htmlBody = '<!DOCTYPE html><html><head><meta charset="UTF-8"></head><body style="font-family:Arial,sans-serif;background:#f1f5f9;padding:20px">';
+$htmlBody  = '<!DOCTYPE html><html><head><meta charset="UTF-8"></head><body style="font-family:Arial,sans-serif;background:#f1f5f9;padding:20px">';
 $htmlBody .= '<div style="max-width:500px;margin:0 auto;background:#fff;border-radius:12px;padding:32px;box-shadow:0 2px 8px rgba(0,0,0,.1)">';
 $htmlBody .= '<div style="text-align:center;margin-bottom:24px">';
 $htmlBody .= '<div style="width:56px;height:56px;background:#3b82f6;border-radius:50%;margin:0 auto 12px;display:flex;align-items:center;justify-content:center">';
@@ -87,11 +76,12 @@ $htmlBody .= '<span style="color:#fff;font-size:24px">&#128274;</span>';
 $htmlBody .= '</div>';
 $htmlBody .= '<h2 style="color:#1e293b;margin:0">Restablecer Contrasena</h2>';
 $htmlBody .= '</div>';
-$htmlBody .= '<p style="color:#475569;font-size:15px;line-height:1.6">Se ha solicitado un restablecimiento de contrasena para el <strong>Admin Panel</strong> de Imporlan.</p>';
+$htmlBody .= '<p style="color:#475569;font-size:15px;line-height:1.6">Se ha solicitado un restablecimiento de contrasena para el <strong>Admin Panel</strong> de Imporlan' . ($isTest ? ' (entorno de pruebas)' : '') . '.</p>';
 $htmlBody .= '<p style="color:#475569;font-size:15px;line-height:1.6">Haz clic en el boton de abajo para crear una nueva contrasena:</p>';
 $htmlBody .= '<div style="text-align:center;margin:28px 0">';
 $htmlBody .= '<a href="' . htmlspecialchars($resetUrl) . '" style="display:inline-block;background:#3b82f6;color:#fff;padding:14px 32px;border-radius:10px;text-decoration:none;font-size:15px;font-weight:600">Restablecer Contrasena</a>';
 $htmlBody .= '</div>';
+$htmlBody .= '<p style="color:#94a3b8;font-size:12px;text-align:center;word-break:break-all">O copia este enlace en tu navegador:<br>' . htmlspecialchars($resetUrl) . '</p>';
 $htmlBody .= '<div style="background:#f8fafc;border-radius:8px;padding:12px 16px;margin:16px 0">';
 $htmlBody .= '<p style="margin:4px 0;color:#64748b;font-size:13px"><strong>Fecha:</strong> ' . $date . '</p>';
 $htmlBody .= '<p style="margin:4px 0;color:#64748b;font-size:13px"><strong>Expira en:</strong> 1 hora</p>';
@@ -102,50 +92,29 @@ $htmlBody .= '<p style="color:#94a3b8;font-size:12px;text-align:center">Notifica
 $htmlBody .= '</div></body></html>';
 
 try {
-    $errno = 0;
-    $errstr = '';
-    $context = stream_context_create([
-        'ssl' => ['verify_peer' => false, 'verify_peer_name' => false, 'allow_self_signed' => true]
-    ]);
-    $smtp = @stream_socket_client("ssl://$smtpHost:$smtpPort", $errno, $errstr, 30, STREAM_CLIENT_CONNECT, $context);
-    if (!$smtp) {
-        throw new Exception("SMTP connect failed: $errstr ($errno)");
-    }
+    require_once __DIR__ . '/email_service.php';
+    $emailService = new EmailService();
+    $result = $emailService->sendCustomEmail($to, $subject, $htmlBody);
 
-    fgets($smtp, 515);
-    fwrite($smtp, "EHLO imporlan.cl\r\n"); fgets($smtp, 515);
-    while ($line = fgets($smtp, 515)) { if ($line[3] === ' ') break; }
-    fwrite($smtp, "AUTH LOGIN\r\n"); fgets($smtp, 515);
-    fwrite($smtp, base64_encode($smtpUser) . "\r\n"); fgets($smtp, 515);
-    fwrite($smtp, base64_encode($smtpPass) . "\r\n"); fgets($smtp, 515);
-    fwrite($smtp, "MAIL FROM:<$smtpUser>\r\n"); fgets($smtp, 515);
-    fwrite($smtp, "RCPT TO:<$to>\r\n"); fgets($smtp, 515);
-    fwrite($smtp, "DATA\r\n"); fgets($smtp, 515);
-
-    $headers = "From: Imporlan <$smtpUser>\r\n";
-    $headers .= "To: $to\r\n";
-    $headers .= "Subject: $subject\r\n";
-    $headers .= "MIME-Version: 1.0\r\n";
-    $headers .= "Content-Type: text/html; charset=UTF-8\r\n";
-    $headers .= "Date: " . date('r') . "\r\n";
-    $headers .= "Message-ID: <" . uniqid('imporlan_admin_reset_', true) . "@imporlan.cl>\r\n";
-    $headers .= "\r\n";
-
-    fwrite($smtp, $headers . $htmlBody . "\r\n.\r\n");
-    $dataResp = fgets($smtp, 515);
-    fwrite($smtp, "QUIT\r\n");
-    fclose($smtp);
-
-    if (strpos($dataResp, '250') !== false) {
+    if (!empty($result['success'])) {
         echo json_encode([
             'success' => true,
-            'message' => 'Se ha enviado un enlace de recuperacion a contacto@imporlan.cl. Revisa tu bandeja de entrada.'
+            'message' => 'Se envio un enlace de recuperacion al correo del administrador (' . $to . '). Revisa la bandeja de entrada y la carpeta de spam; puede tardar 1-2 minutos.'
         ]);
     } else {
-        throw new Exception("SMTP DATA response: $dataResp");
+        $err = isset($result['error']) ? $result['error'] : 'Error desconocido al enviar el correo';
+        error_log('admin_forgot_password: send failed - ' . $err);
+        http_response_code(500);
+        echo json_encode([
+            'error'  => 'No se pudo enviar el correo de recuperacion. Verifica la configuracion SMTP o intenta nuevamente.',
+            'detail' => $err
+        ]);
     }
 } catch (Exception $e) {
-    error_log("Error in admin_forgot_password: " . $e->getMessage());
+    error_log('admin_forgot_password exception: ' . $e->getMessage());
     http_response_code(500);
-    echo json_encode(['error' => 'Error al enviar el correo. Intenta nuevamente.']);
+    echo json_encode([
+        'error'  => 'Error al enviar el correo de recuperacion.',
+        'detail' => $e->getMessage()
+    ]);
 }

--- a/test/api/admin_forgot_password.php
+++ b/test/api/admin_forgot_password.php
@@ -1,8 +1,10 @@
 <?php
 /**
  * Admin Forgot Password - Imporlan Admin Panel (TEST)
+ *
  * Generates a secure reset token, stores it on the server, and emails
- * a reset link to contacto@imporlan.cl so the admin can set a new password.
+ * a reset link to contacto@imporlan.cl using the shared EmailService,
+ * which loads its SMTP credentials from /home/wwimpo/smtp_config.php.
  */
 header('Access-Control-Allow-Origin: *');
 header('Access-Control-Allow-Methods: POST, OPTIONS');
@@ -29,18 +31,15 @@ if (!$email || strpos($email, '@') === false) {
     exit();
 }
 
-// Only allow admin email
 if ($email !== 'admin@imporlan.cl') {
     http_response_code(400);
     echo json_encode(['error' => 'Este formulario es solo para el administrador.']);
     exit();
 }
 
-// Generate secure token
 $token = bin2hex(random_bytes(32));
 $expiry = time() + 3600; // 1 hour
 
-// Store token in a file (one token at a time for admin)
 $tokenDir = __DIR__ . '/../.admin_reset_tokens';
 if (!is_dir($tokenDir)) {
     mkdir($tokenDir, 0700, true);
@@ -51,30 +50,23 @@ if (!file_exists($htaccess)) {
 }
 $tokenFile = $tokenDir . '/token.json';
 file_put_contents($tokenFile, json_encode([
-    'token' => hash('sha256', $token),
-    'email' => $email,
-    'expiry' => $expiry,
-    'ip' => isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : 'unknown',
+    'token'   => hash('sha256', $token),
+    'email'   => $email,
+    'expiry'  => $expiry,
+    'ip'      => isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : 'unknown',
     'created' => date('Y-m-d H:i:s')
 ]));
 
-// Build reset URL
 $scheme = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https' : 'http';
 $host = isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : 'www.imporlan.cl';
 $resetUrl = $scheme . '://' . $host . '/test/api/admin_reset_password.php?token=' . $token;
-
-// SMTP configuration
-$smtpHost = 'mail.imporlan.cl';
-$smtpPort = 465;
-$smtpUser = 'contacto@imporlan.cl';
-$smtpPass = '^IBn?P-Z5@#_';
 
 $to = 'contacto@imporlan.cl';
 $date = date('d/m/Y H:i:s');
 
 $subject = '[TEST] Restablecer contrasena - Admin Panel Imporlan';
 
-$htmlBody = '<!DOCTYPE html><html><head><meta charset="UTF-8"></head><body style="font-family:Arial,sans-serif;background:#f1f5f9;padding:20px">';
+$htmlBody  = '<!DOCTYPE html><html><head><meta charset="UTF-8"></head><body style="font-family:Arial,sans-serif;background:#f1f5f9;padding:20px">';
 $htmlBody .= '<div style="max-width:500px;margin:0 auto;background:#fff;border-radius:12px;padding:32px;box-shadow:0 2px 8px rgba(0,0,0,.1)">';
 $htmlBody .= '<div style="text-align:center;margin-bottom:24px">';
 $htmlBody .= '<div style="width:56px;height:56px;background:#3b82f6;border-radius:50%;margin:0 auto 12px;display:flex;align-items:center;justify-content:center">';
@@ -87,6 +79,7 @@ $htmlBody .= '<p style="color:#475569;font-size:15px;line-height:1.6">Haz clic e
 $htmlBody .= '<div style="text-align:center;margin:28px 0">';
 $htmlBody .= '<a href="' . htmlspecialchars($resetUrl) . '" style="display:inline-block;background:#3b82f6;color:#fff;padding:14px 32px;border-radius:10px;text-decoration:none;font-size:15px;font-weight:600">Restablecer Contrasena</a>';
 $htmlBody .= '</div>';
+$htmlBody .= '<p style="color:#94a3b8;font-size:12px;text-align:center;word-break:break-all">O copia este enlace en tu navegador:<br>' . htmlspecialchars($resetUrl) . '</p>';
 $htmlBody .= '<div style="background:#f8fafc;border-radius:8px;padding:12px 16px;margin:16px 0">';
 $htmlBody .= '<p style="margin:4px 0;color:#64748b;font-size:13px"><strong>Fecha:</strong> ' . $date . '</p>';
 $htmlBody .= '<p style="margin:4px 0;color:#64748b;font-size:13px"><strong>Expira en:</strong> 1 hora</p>';
@@ -97,50 +90,29 @@ $htmlBody .= '<p style="color:#94a3b8;font-size:12px;text-align:center">Notifica
 $htmlBody .= '</div></body></html>';
 
 try {
-    $errno = 0;
-    $errstr = '';
-    $context = stream_context_create([
-        'ssl' => ['verify_peer' => false, 'verify_peer_name' => false, 'allow_self_signed' => true]
-    ]);
-    $smtp = @stream_socket_client("ssl://$smtpHost:$smtpPort", $errno, $errstr, 30, STREAM_CLIENT_CONNECT, $context);
-    if (!$smtp) {
-        throw new Exception("SMTP connect failed: $errstr ($errno)");
-    }
+    require_once __DIR__ . '/email_service.php';
+    $emailService = new EmailService();
+    $result = $emailService->sendCustomEmail($to, $subject, $htmlBody);
 
-    fgets($smtp, 515);
-    fwrite($smtp, "EHLO imporlan.cl\r\n"); fgets($smtp, 515);
-    while ($line = fgets($smtp, 515)) { if ($line[3] === ' ') break; }
-    fwrite($smtp, "AUTH LOGIN\r\n"); fgets($smtp, 515);
-    fwrite($smtp, base64_encode($smtpUser) . "\r\n"); fgets($smtp, 515);
-    fwrite($smtp, base64_encode($smtpPass) . "\r\n"); fgets($smtp, 515);
-    fwrite($smtp, "MAIL FROM:<$smtpUser>\r\n"); fgets($smtp, 515);
-    fwrite($smtp, "RCPT TO:<$to>\r\n"); fgets($smtp, 515);
-    fwrite($smtp, "DATA\r\n"); fgets($smtp, 515);
-
-    $headers = "From: Imporlan <$smtpUser>\r\n";
-    $headers .= "To: $to\r\n";
-    $headers .= "Subject: $subject\r\n";
-    $headers .= "MIME-Version: 1.0\r\n";
-    $headers .= "Content-Type: text/html; charset=UTF-8\r\n";
-    $headers .= "Date: " . date('r') . "\r\n";
-    $headers .= "Message-ID: <" . uniqid('imporlan_admin_reset_test_', true) . "@imporlan.cl>\r\n";
-    $headers .= "\r\n";
-
-    fwrite($smtp, $headers . $htmlBody . "\r\n.\r\n");
-    $dataResp = fgets($smtp, 515);
-    fwrite($smtp, "QUIT\r\n");
-    fclose($smtp);
-
-    if (strpos($dataResp, '250') !== false) {
+    if (!empty($result['success'])) {
         echo json_encode([
             'success' => true,
-            'message' => 'Se ha enviado un enlace de recuperacion a contacto@imporlan.cl. Revisa tu bandeja de entrada.'
+            'message' => 'Se envio un enlace de recuperacion al correo del administrador (' . $to . '). Revisa la bandeja de entrada y la carpeta de spam; puede tardar 1-2 minutos.'
         ]);
     } else {
-        throw new Exception("SMTP DATA response: $dataResp");
+        $err = isset($result['error']) ? $result['error'] : 'Error desconocido al enviar el correo';
+        error_log('admin_forgot_password (test): send failed - ' . $err);
+        http_response_code(500);
+        echo json_encode([
+            'error'  => 'No se pudo enviar el correo de recuperacion. Verifica la configuracion SMTP o intenta nuevamente.',
+            'detail' => $err
+        ]);
     }
 } catch (Exception $e) {
-    error_log("Error in admin_forgot_password (test): " . $e->getMessage());
+    error_log('admin_forgot_password (test) exception: ' . $e->getMessage());
     http_response_code(500);
-    echo json_encode(['error' => 'Error al enviar el correo. Intenta nuevamente.']);
+    echo json_encode([
+        'error'  => 'Error al enviar el correo de recuperacion.',
+        'detail' => $e->getMessage()
+    ]);
 }


### PR DESCRIPTION
## Summary

Principal fix (commit `5c4890e`): el endpoint de recuperación de contraseña del Admin Panel (`api/admin_forgot_password.php`) reimplementaba SMTP con credenciales hardcodeadas que no coinciden con producción. Ahora usa `EmailService::sendCustomEmail()`, que carga el password real desde `/home/wwimpo/smtp_config.php` y verifica la respuesta del `AUTH LOGIN`. También se propaga el `detail` del error al modal cuando falla, en vez de reportar éxito en silencio.

Esta rama también incluye 7 commits previos no mergeados sobre el flujo de correos automatizados:

- `1a28204` Externalize SMTP credentials and fix lying success in `sendQuotationFormEmail`
- `d1bac29` Fix automated post-purchase emails for WebPay payments
- `26c6738` Merge: fix automated post-purchase emails (WebPay + SMTP credentials externalization)
- `2d92de4` Include `boat_links` in quotation form email when payer email differs from form email
- `c280550` Merge: include `boat_links` fallback in post-payment quotation form email
- `e102e64` Render the actual contracted `boat_links` in payment confirmation emails
- `c6d9744` Merge: render actual `boat_links` in payment confirmation emails

## Test plan

- [ ] Probar "¿Olvidaste tu contraseña?" en `/admin/`, recibir el correo en `contacto@imporlan.cl` y completar el reset
- [ ] Verificar que un fallo de SMTP ahora se muestra al usuario (modal con `detail`) en vez de reportar éxito
- [ ] Validar correos automatizados post-pago en WebPay (sandbox)
- [ ] Validar `boat_links` se rendrizan en el correo de confirmación de pago
- [ ] Confirmar que el auto-deploy (cron) toma el merge y publica a producción

https://claude.ai/code/session_01TC2GHyRqyWwuNopX4ArsEE

---
_Generated by [Claude Code](https://claude.ai/code/session_01TC2GHyRqyWwuNopX4ArsEE)_