### PR TITLE
Add Fly.io BoatTrader scraper source for redeploy

### DIFF
--- a/scraper/.dockerignore
+++ b/scraper/.dockerignore
@@ -1,0 +1,10 @@
+__pycache__
+*.pyc
+*.pyo
+.venv
+venv
+.env
+.git
+.gitignore
+README.md
+fly.toml

--- a/scraper/Dockerfile
+++ b/scraper/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:3.12-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+WORKDIR /app
+
+# curl_cffi ships native binaries that need libssl/libffi at runtime;
+# the slim image already has them, but keep ca-certificates fresh.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app.py .
+
+EXPOSE 8080
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8080", "--workers", "2"]

--- a/scraper/README.md
+++ b/scraper/README.md
@@ -1,0 +1,94 @@
+# Imporlan BoatTrader Scraper
+
+FastAPI service that bypasses Cloudflare on `boattrader.com` / `boats.com`
+using `curl_cffi` (TLS fingerprint impersonation) and returns structured
+listing data. Called by `api/boattrader_scraper.php` from the panel.
+
+## Endpoints
+
+- `GET /` — service info
+- `GET /health` — health check (used by Fly.io)
+- `GET /scrape?url=<listing_url>` — scrape a listing
+
+## Response shape
+
+```json
+{
+  "success": true,
+  "title": "2006 Sea Ray 200 Sundeck",
+  "price": 18900.0,
+  "location": "Miami, FL",
+  "city": "Miami, FL",
+  "hours": 350,
+  "engine": "Mercruiser 4.5L",
+  "image_url": "https://imageresizer.boats.com/...",
+  "listing_id": "10163201",
+  "source": "next_data"
+}
+```
+
+## Deploying to Fly.io (cPanel terminal)
+
+These steps run on the cPanel server, in this directory.
+
+```bash
+# 1. Install flyctl (one-time)
+curl -L https://fly.io/install.sh | sh
+export FLYCTL_INSTALL="$HOME/.fly"
+export PATH="$FLYCTL_INSTALL/bin:$PATH"
+
+# 2. Login (opens a browser link, paste it where you can)
+flyctl auth login
+
+# 3. From this directory: launch (only the FIRST time — creates the app)
+cd /home/wwimpo/imporlan-staging/scraper
+flyctl launch --no-deploy --copy-config --name imporlan-boattrader-scraper
+# When asked: don't add Postgres, don't add Redis, don't deploy yet.
+# It will write a fresh fly.toml — overwrite if asked, or keep ours.
+
+# 4. Deploy
+flyctl deploy
+
+# 5. Verify
+flyctl status
+flyctl logs
+
+# 6. Smoke test
+curl -sS "https://imporlan-boattrader-scraper.fly.dev/health"
+curl -sS "https://imporlan-boattrader-scraper.fly.dev/scrape?url=https://www.boattrader.com/boat/2006-sea-ray-200-sundeck-10163201/" | head -c 1000
+```
+
+If `flyctl launch` complains the app name is taken, pick another (e.g.
+`imporlan-scraper-XYZ`) and update `app = "..."` in `fly.toml` plus the
+URL in `api/boattrader_scraper.php` accordingly.
+
+## Updating the panel to use this scraper
+
+Once `flyctl deploy` succeeds and the smoke test returns data, edit:
+
+`api/boattrader_scraper.php` line ~659:
+
+```php
+$apiBase = 'https://imporlan-boattrader-scraper.fly.dev';
+```
+
+(Use whatever hostname Fly assigned — `flyctl status` shows it.)
+
+Then commit + run `bash deploy-prod.sh`.
+
+## Iterating
+
+If the scraper runs but returns partial data:
+
+1. `flyctl logs` to see what happened
+2. Test locally: hit `/scrape?url=...` and inspect the JSON
+3. Common cause: BoatTrader changed the `__NEXT_DATA__` schema; update the
+   key candidates in `_from_next_data()` accordingly. The fallback `_from_meta`
+   should still cover title + image even if Next data parsing fails.
+
+## Costs
+
+Fly.io's free Hobby plan covers a single shared-cpu-1x 256-512 MB machine.
+With `auto_stop_machines = "suspend"`, the machine stops after a few minutes
+of inactivity and starts automatically on the next request (cold start ~2 s).
+Expected cost for normal panel usage: $0.

--- a/scraper/app.py
+++ b/scraper/app.py
@@ -1,0 +1,340 @@
+"""
+Imporlan BoatTrader Scraper
+===========================
+FastAPI service that bypasses Cloudflare on boattrader.com / boats.com using
+curl_cffi (TLS fingerprint impersonation) and returns structured listing data.
+
+Deployed on Fly.io. Called by api/boattrader_scraper.php fetchViaScraperAPI().
+
+Response shape (kept compatible with the previous scraper):
+    {
+        "success": true,
+        "title": "2006 Sea Ray 200 Sundeck",
+        "price": 18900.0,
+        "location": "Miami, FL",
+        "city": "Miami, FL",
+        "hours": 350,
+        "engine": "Mercruiser 4.5L",
+        "image_url": "https://imageresizer.boats.com/...",
+        "listing_id": "10163201",
+        "source": "next_data"
+    }
+"""
+
+import json
+import logging
+import re
+from typing import Any
+
+from bs4 import BeautifulSoup
+from curl_cffi import requests as curl_requests
+from fastapi import FastAPI, HTTPException, Query
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("scraper")
+
+app = FastAPI(title="Imporlan BoatTrader Scraper", version="1.0.0")
+
+
+@app.get("/")
+def root():
+    return {"status": "ok", "service": "imporlan-boattrader-scraper", "version": "1.0.0"}
+
+
+@app.get("/health")
+def health():
+    return {"ok": True}
+
+
+@app.get("/scrape")
+def scrape(url: str = Query(..., description="boattrader.com or boats.com listing URL")):
+    if not _is_supported_url(url):
+        raise HTTPException(status_code=400, detail="Only boattrader.com and boats.com URLs are supported")
+
+    log.info("scrape url=%s", url)
+    try:
+        r = curl_requests.get(url, impersonate="chrome120", timeout=25, allow_redirects=True)
+    except Exception as e:
+        log.exception("fetch failed")
+        return {"success": False, "error": f"fetch_failed: {e}"}
+
+    if r.status_code != 200:
+        log.warning("fetch http=%s url=%s", r.status_code, url)
+        return {"success": False, "error": f"http_{r.status_code}"}
+
+    html = r.text
+    if not html or len(html) < 500:
+        return {"success": False, "error": "empty_html"}
+
+    return _parse(url, html)
+
+
+def _is_supported_url(url: str) -> bool:
+    return any(d in url for d in ("boattrader.com", "boats.com"))
+
+
+def _listing_id_from_url(url: str) -> str | None:
+    m = re.search(r"-(\d{6,})/?(?:\?|$)", url)
+    return m.group(1) if m else None
+
+
+def _parse(url: str, html: str) -> dict[str, Any]:
+    soup = BeautifulSoup(html, "lxml")
+    listing_id = _listing_id_from_url(url)
+
+    # Strategy 1: __NEXT_DATA__ (most complete, BoatTrader uses Next.js)
+    next_data = _read_next_data(soup)
+    if next_data:
+        out = _from_next_data(next_data, url, listing_id)
+        if out and out.get("title"):
+            return out
+
+    # Strategy 2: JSON-LD + og: meta (works as fallback or on boats.com)
+    out = _from_meta(soup, url, listing_id)
+    if out.get("title") or out.get("image_url"):
+        out["success"] = True
+        return out
+
+    return {"success": False, "error": "no_data_extracted", "listing_id": listing_id, "url": url}
+
+
+def _read_next_data(soup: BeautifulSoup) -> dict | None:
+    tag = soup.find("script", id="__NEXT_DATA__")
+    if not tag or not tag.string:
+        return None
+    try:
+        return json.loads(tag.string)
+    except Exception:
+        log.exception("__NEXT_DATA__ parse failed")
+        return None
+
+
+def _walk(obj, predicate):
+    """Yield every dict in a nested structure that matches predicate(dict)."""
+    if isinstance(obj, dict):
+        if predicate(obj):
+            yield obj
+        for v in obj.values():
+            yield from _walk(v, predicate)
+    elif isinstance(obj, list):
+        for v in obj:
+            yield from _walk(v, predicate)
+
+
+def _first(*vals):
+    for v in vals:
+        if v not in (None, "", 0):
+            return v
+    return None
+
+
+def _to_float(v):
+    if v is None:
+        return None
+    if isinstance(v, (int, float)):
+        return float(v)
+    if isinstance(v, str):
+        clean = re.sub(r"[^\d.]", "", v)
+        try:
+            return float(clean) if clean else None
+        except ValueError:
+            return None
+    return None
+
+
+def _to_int(v):
+    f = _to_float(v)
+    return int(f) if f is not None else None
+
+
+def _from_next_data(data: dict, url: str, listing_id) -> dict | None:
+    # The listing object varies by route — find it heuristically.
+    # We look for a dict that has BOTH a price-ish field AND an images-ish field.
+    candidates = list(_walk(
+        data,
+        lambda d: any(k in d for k in ("price", "Price", "askingPrice"))
+                  and any(k in d for k in ("images", "Images", "imageUrls", "media")),
+    ))
+    listing = candidates[0] if candidates else None
+
+    # Fallback: any dict with title/make/model AND a price
+    if not listing:
+        candidates = list(_walk(
+            data,
+            lambda d: any(k in d for k in ("title", "Title", "make", "Make"))
+                      and any(k in d for k in ("price", "Price", "askingPrice")),
+        ))
+        listing = candidates[0] if candidates else None
+
+    if not listing:
+        return None
+
+    # Title
+    title = _first(
+        listing.get("title"),
+        listing.get("Title"),
+        " ".join(filter(None, [
+            str(listing.get("year") or listing.get("Year") or ""),
+            str(listing.get("make") or listing.get("Make") or ""),
+            str(listing.get("model") or listing.get("Model") or ""),
+        ])).strip(),
+    ) or ""
+
+    # Price
+    raw_price = _first(
+        listing.get("price"),
+        listing.get("Price"),
+        listing.get("askingPrice"),
+    )
+    if isinstance(raw_price, dict):
+        raw_price = _first(
+            raw_price.get("amount"),
+            raw_price.get("value"),
+            raw_price.get("Value"),
+        )
+    price = _to_float(raw_price)
+
+    # Location
+    location = ""
+    loc = _first(
+        listing.get("location"),
+        listing.get("Location"),
+        listing.get("address"),
+    )
+    if isinstance(loc, dict):
+        city = _first(loc.get("city"), loc.get("City")) or ""
+        state = _first(loc.get("state"), loc.get("State"), loc.get("region")) or ""
+        location = ", ".join(p for p in (city, state) if p)
+    elif isinstance(loc, str):
+        location = loc
+    else:
+        # try direct fields
+        city = _first(listing.get("city"), listing.get("City"))
+        state = _first(listing.get("state"), listing.get("State"))
+        if city:
+            location = ", ".join(p for p in (str(city), str(state) if state else "") if p)
+
+    # Hours
+    hours = _to_int(_first(
+        listing.get("hours"),
+        listing.get("Hours"),
+        listing.get("engineHours"),
+    ))
+
+    # Engine
+    engine = ""
+    eng = _first(
+        listing.get("engine"),
+        listing.get("Engine"),
+        listing.get("primaryEngine"),
+        listing.get("PrimaryEngine"),
+    )
+    if isinstance(eng, dict):
+        engine = _first(
+            eng.get("description"),
+            eng.get("Description"),
+            eng.get("model"),
+            eng.get("name"),
+        ) or ""
+    elif isinstance(eng, str):
+        engine = eng
+
+    # Image
+    image_url = ""
+    img = _first(
+        listing.get("primaryImage"),
+        listing.get("image"),
+        listing.get("imageUrl"),
+        listing.get("ImageUrl"),
+    )
+    if isinstance(img, dict):
+        image_url = _first(img.get("url"), img.get("Url"), img.get("uri")) or ""
+    elif isinstance(img, str):
+        image_url = img
+
+    if not image_url:
+        images = _first(
+            listing.get("images"),
+            listing.get("Images"),
+            listing.get("imageUrls"),
+            listing.get("media"),
+        )
+        if isinstance(images, list) and images:
+            first = images[0]
+            if isinstance(first, str):
+                image_url = first
+            elif isinstance(first, dict):
+                image_url = _first(
+                    first.get("url"), first.get("Url"), first.get("uri"),
+                    first.get("XLargeURL"), first.get("LargeURL"), first.get("MediumURL"),
+                ) or ""
+
+    return {
+        "success": bool(title or image_url),
+        "title": title,
+        "price": price,
+        "location": location,
+        "city": location,
+        "hours": hours,
+        "engine": engine,
+        "image_url": image_url,
+        "listing_id": listing_id,
+        "url": url,
+        "source": "next_data",
+    }
+
+
+def _from_meta(soup: BeautifulSoup, url: str, listing_id) -> dict[str, Any]:
+    # og: meta
+    og = lambda p: (soup.find("meta", property=p) or {}).get("content", "") if soup.find("meta", property=p) else ""
+    title = (og("og:title") or "").strip()
+    image_url = (og("og:image") or "").strip()
+    description = (og("og:description") or "").strip()
+
+    # JSON-LD: Product / Vehicle / Boat with offers.price
+    price = None
+    location = ""
+    for ld in soup.find_all("script", attrs={"type": "application/ld+json"}):
+        if not ld.string:
+            continue
+        try:
+            payload = json.loads(ld.string)
+        except Exception:
+            continue
+        items = payload if isinstance(payload, list) else [payload]
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            offers = item.get("offers")
+            if isinstance(offers, dict) and price is None:
+                p = offers.get("price") or offers.get("lowPrice")
+                price = _to_float(p)
+            if not title and item.get("name"):
+                title = str(item["name"])
+            if not image_url and item.get("image"):
+                im = item["image"]
+                if isinstance(im, list) and im:
+                    image_url = str(im[0])
+                elif isinstance(im, str):
+                    image_url = im
+            # Location may live under offers.areaServed or item.location
+            for loc_key in ("areaServed", "location"):
+                loc = (offers.get(loc_key) if isinstance(offers, dict) else None) or item.get(loc_key)
+                if isinstance(loc, dict) and not location:
+                    addr = loc.get("address") if isinstance(loc.get("address"), dict) else loc
+                    city = addr.get("addressLocality") or addr.get("city") or ""
+                    state = addr.get("addressRegion") or addr.get("state") or ""
+                    location = ", ".join(p for p in (city, state) if p)
+
+    return {
+        "title": title,
+        "price": price,
+        "location": location,
+        "city": location,
+        "hours": None,
+        "engine": "",
+        "image_url": image_url,
+        "listing_id": listing_id,
+        "url": url,
+        "source": "meta",
+    }

--- a/scraper/fly.toml
+++ b/scraper/fly.toml
@@ -1,0 +1,28 @@
+app = "imporlan-boattrader-scraper"
+primary_region = "scl"
+
+[build]
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = "suspend"
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ["app"]
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "512mb"
+  cpu_kind = "shared"
+  cpus = 1
+
+[checks]
+  [checks.health]
+    grace_period = "10s"
+    interval = "30s"
+    method = "GET"
+    path = "/health"
+    port = 8080
+    timeout = "5s"
+    type = "http"

--- a/scraper/requirements.txt
+++ b/scraper/requirements.txt
@@ -1,0 +1,5 @@
+fastapi==0.115.5
+uvicorn[standard]==0.32.1
+curl_cffi==0.7.4
+beautifulsoup4==4.12.3
+lxml==5.3.0


### PR DESCRIPTION
## Summary

El scraper de Fly.io (`boattrader-scraper-jocitetw.fly.dev`) fue eliminado y el panel está cayendo al fallback de extraer datos del path del URL (solo año/marca/modelo, sin imagen, sin precio, sin ubicación real). Este PR mete al repo el código fuente del scraper para que lo redeployes en tu propia cuenta de Fly.io.

## Stack

- **FastAPI** + **uvicorn** sobre **python:3.12-slim** en Docker
- **curl_cffi** con `impersonate="chrome120"` para bypassear el TLS fingerprinting de Cloudflare
- **BeautifulSoup + lxml** para parseo HTML
- 2 estrategias de extracción: Next.js `__NEXT_DATA__` (primaria) → og:meta + JSON-LD (fallback)

## Response shape

Mantengo la misma forma que el scraper anterior, así no hay que tocar `api/boattrader_scraper.php` salvo el hostname:

```json
{
  "success": true,
  "title": "2006 Sea Ray 200 Sundeck",
  "price": 18900.0,
  "location": "Miami, FL",
  "city": "Miami, FL",
  "hours": 350,
  "engine": "Mercruiser 4.5L",
  "image_url": "https://imageresizer.boats.com/...",
  "listing_id": "10163201",
  "source": "next_data"
}
```

## Test plan (post-deploy del PR)

- [ ] Mergear este PR (no toca producción todavía, solo agrega `/scraper/`)
- [ ] Seguir los pasos en `scraper/README.md` desde el terminal cPanel para deployar a Fly.io
- [ ] Smoke test: `curl https://imporlan-boattrader-scraper.fly.dev/health` y `?action=scrape&url=...`
- [ ] Una vez funcionando, **otro PR** actualiza `api/boattrader_scraper.php:659` con la URL nueva

## Costo

Free tier de Fly.io. Con `auto_stop_machines="suspend"` la máquina se duerme cuando no hay tráfico — costo esperado **$0** para el uso normal del panel.

https://claude.ai/code/session_01TC2GHyRqyWwuNopX4ArsEE

---
_Generated by [Claude Code](https://claude.ai/code/session_01TC2GHyRqyWwuNopX4ArsEE)_