### PR TITLE
Connect panel to new BoatTrader scraper Fly.io URL

### DIFF
--- a/api/boattrader_scraper.php
+++ b/api/boattrader_scraper.php
@@ -656,7 +656,7 @@ function fetchMetaViaDDG($slug, $listingId) {
  * @return array|null Extracted data or null on failure
  */
 function fetchViaScraperAPI($url) {
-    $apiBase = 'https://boattrader-scraper-jocitetw.fly.dev';
+    $apiBase = 'https://imporlan-boattrader-scraper.fly.dev';
     $apiUrl = $apiBase . '/scrape?url=' . urlencode($url);
 
     $ch = curl_init();

--- a/test/api/boattrader_scraper.php
+++ b/test/api/boattrader_scraper.php
@@ -656,7 +656,7 @@ function fetchMetaViaDDG($slug, $listingId) {
  * @return array|null Extracted data or null on failure
  */
 function fetchViaScraperAPI($url) {
-    $apiBase = 'https://boattrader-scraper-jocitetw.fly.dev';
+    $apiBase = 'https://imporlan-boattrader-scraper.fly.dev';
     $apiUrl = $apiBase . '/scrape?url=' . urlencode($url);
 
     $ch = curl_init();


### PR DESCRIPTION
## Summary

Conecta el panel al scraper recién desplegado en Fly.io. Solo cambia 2 líneas (prod + test) — el hostname del scraper.

Antes: `https://boattrader-scraper-jocitetw.fly.dev` (dead)
Después: `https://imporlan-boattrader-scraper.fly.dev` (live, deployed in iad)

Verificado en vivo:
```bash
$ curl 'https://imporlan-boattrader-scraper.fly.dev/scrape?url=https://www.boattrader.com/boat/2006-sea-ray-200-sundeck-10163201/'
{"title":"2006 Sea Ray 200 Sundeck","price":18000.0,"image_url":"https://images.boattrader.com/...","success":true,...}
```

## Test plan

- [ ] Tras `bash deploy-prod.sh`, agregar un link de BoatTrader en un expediente del panel
- [ ] Verificar que se capturan: título, precio, imagen
- [ ] Conocido: `location`, `hours`, `engine` vienen vacíos por ahora — se mejoran en un follow-up

https://claude.ai/code/session_01TC2GHyRqyWwuNopX4ArsEE

---
_Generated by [Claude Code](https://claude.ai/code/session_01TC2GHyRqyWwuNopX4ArsEE)_