### PR TITLE
Scraper: word-boundary match in _find_in_specs

### DIFF
--- a/scraper/app.py
+++ b/scraper/app.py
@@ -573,10 +573,13 @@ def _extract_specs_from_html(soup: BeautifulSoup) -> dict:
 
 
 def _find_in_specs(specs: dict, *keys) -> str | None:
-    """Find first value whose key contains any of the given key fragments (case-insensitive)."""
+    """Find first value whose key contains any of the given key fragments as a
+    whole word (case-insensitive). Whole-word matching avoids the bug where
+    "city" matches "capacity" — "fuel capacity: 18.5 gal" used to leak as the
+    location value."""
     for k in keys:
-        kl = k.lower()
+        pattern = re.compile(r"\b" + re.escape(k.lower()) + r"\b", re.I)
         for spec_key, val in specs.items():
-            if kl in spec_key:
+            if pattern.search(spec_key):
                 return val
     return None


### PR DESCRIPTION
## Summary

Bug residual del location: aún devolvía `"18.5 gal"` aunque el title regex ya rechazaba unidades. Causa real: **`_find_in_specs` hacía substring match**, y la palabra `"city"` es subcadena de `"capacity"`. Entonces `fuel capacity: 18.5 gal` se leía como ubicación.

Fix: pasar `_find_in_specs` a regex con `\b` (word boundary). Ahora `"city"` solo matchea `"city"` como palabra completa.

Verificado:
- `"fuel capacity"` → buscar `"city"` → `None` (antes: `"18.5 gal"`)
- `"city": "Mankato"` → buscar `"city"` → `"Mankato"` (sigue OK)
- `"boat location"` → buscar `"location"` → la value (sigue OK)

## Test plan

- [ ] `flyctl deploy` desde `/scraper/`
- [ ] Probar la URL de WaveRunner: location debe venir vacío (no "18.5 gal")
- [ ] Probar la URL de Sea Ray Sundeck: location debe seguir siendo "Mankato"

https://claude.ai/code/session_01TC2GHyRqyWwuNopX4ArsEE

---
_Generated by [Claude Code](https://claude.ai/code/session_01TC2GHyRqyWwuNopX4ArsEE)_