### PR TITLE
Cotizador: self-migrate order_links columns from helpers

### DIFF
--- a/api/cotizador_helpers.php
+++ b/api/cotizador_helpers.php
@@ -8,6 +8,39 @@ if (!defined('IMPORLAN_COTIZADOR_HELPERS_LOADED')) {
     define('IMPORLAN_COTIZADOR_HELPERS_LOADED', true);
 
     /**
+     * Idempotently add the per-link quote columns to order_links. Lives here
+     * (not in settings_api.php) so the cron / lazy-publish path can self-heal
+     * without depending on the admin opening the Cotizador tab first.
+     */
+    function cotizadorEnsureOrderLinkColumns(PDO $pdo): void {
+        $cols = [
+            'quote_data'           => 'JSON NULL',
+            'quote_total_clp'      => 'DECIMAL(15,0) NULL',
+            'quote_total_usd'      => 'DECIMAL(12,2) NULL',
+            'quote_payments'       => 'JSON NULL',
+            'quote_calculated_at'  => 'TIMESTAMP NULL',
+            'quote_published_at'   => 'TIMESTAMP NULL',
+        ];
+        try {
+            $existing = $pdo->query("
+                SELECT COLUMN_NAME FROM information_schema.COLUMNS
+                WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'order_links'
+            ")->fetchAll(PDO::FETCH_COLUMN);
+        } catch (PDOException $e) {
+            return;  // table may not exist yet — skip gracefully
+        }
+        $existingSet = array_flip($existing);
+        foreach ($cols as $col => $def) {
+            if (isset($existingSet[$col])) continue;
+            try {
+                $pdo->exec("ALTER TABLE order_links ADD COLUMN `$col` $def");
+            } catch (PDOException $e) {
+                error_log('cotizadorEnsureOrderLinkColumns: ' . $e->getMessage());
+            }
+        }
+    }
+
+    /**
      * Read the configurable delay (hours) before a saved quote is shown to
      * the client. Falls back to 24 if the row is missing.
      */
@@ -35,6 +68,7 @@ if (!defined('IMPORLAN_COTIZADOR_HELPERS_LOADED')) {
      */
     function cotizadorApplyClientVisibility(PDO $pdo, array $links): array {
         if (empty($links)) return $links;
+        cotizadorEnsureOrderLinkColumns($pdo);  // self-heal in case migration hasn't run yet
         $delayHours = cotizadorClientDelayHours($pdo);
         $now = time();
         $orderCustomer = null;  // lazily loaded if we need to send an email
@@ -106,6 +140,7 @@ if (!defined('IMPORLAN_COTIZADOR_HELPERS_LOADED')) {
      * published in this run.
      */
     function cotizadorPublishDue(PDO $pdo): int {
+        cotizadorEnsureOrderLinkColumns($pdo);  // self-heal: cron may run before admin opens Cotizador tab
         $delayHours = cotizadorClientDelayHours($pdo);
         $stmt = $pdo->prepare("
             SELECT ol.*, o.customer_email, o.customer_name, o.order_number

--- a/api/settings_api.php
+++ b/api/settings_api.php
@@ -561,25 +561,8 @@ function cotizadorSeedDefaults(PDO $pdo): void {
 }
 
 /**
- * Add the per-link quotation columns to order_links if they don't already exist.
- * Idempotent — uses information_schema check so re-runs are no-ops.
+ * cotizadorEnsureOrderLinkColumns now lives in cotizador_helpers.php so the
+ * cron and lazy-publish paths can self-migrate without going through this
+ * file. Keep this stub for any old callers.
  */
-function cotizadorEnsureOrderLinkColumns(PDO $pdo): void {
-    $cols = [
-        'quote_data'           => 'JSON NULL',
-        'quote_total_clp'      => 'DECIMAL(15,0) NULL',
-        'quote_total_usd'      => 'DECIMAL(12,2) NULL',
-        'quote_payments'       => 'JSON NULL',
-        'quote_calculated_at'  => 'TIMESTAMP NULL',
-        'quote_published_at'   => 'TIMESTAMP NULL',
-    ];
-    $existing = $pdo->query("
-        SELECT COLUMN_NAME FROM information_schema.COLUMNS
-        WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'order_links'
-    ")->fetchAll(PDO::FETCH_COLUMN);
-    $existingSet = array_flip($existing);
-    foreach ($cols as $col => $def) {
-        if (isset($existingSet[$col])) continue;
-        $pdo->exec("ALTER TABLE order_links ADD COLUMN `$col` $def");
-    }
-}
+require_once __DIR__ . '/cotizador_helpers.php';

--- a/test/api/cotizador_helpers.php
+++ b/test/api/cotizador_helpers.php
@@ -8,6 +8,39 @@ if (!defined('IMPORLAN_COTIZADOR_HELPERS_LOADED')) {
     define('IMPORLAN_COTIZADOR_HELPERS_LOADED', true);
 
     /**
+     * Idempotently add the per-link quote columns to order_links. Lives here
+     * (not in settings_api.php) so the cron / lazy-publish path can self-heal
+     * without depending on the admin opening the Cotizador tab first.
+     */
+    function cotizadorEnsureOrderLinkColumns(PDO $pdo): void {
+        $cols = [
+            'quote_data'           => 'JSON NULL',
+            'quote_total_clp'      => 'DECIMAL(15,0) NULL',
+            'quote_total_usd'      => 'DECIMAL(12,2) NULL',
+            'quote_payments'       => 'JSON NULL',
+            'quote_calculated_at'  => 'TIMESTAMP NULL',
+            'quote_published_at'   => 'TIMESTAMP NULL',
+        ];
+        try {
+            $existing = $pdo->query("
+                SELECT COLUMN_NAME FROM information_schema.COLUMNS
+                WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'order_links'
+            ")->fetchAll(PDO::FETCH_COLUMN);
+        } catch (PDOException $e) {
+            return;  // table may not exist yet — skip gracefully
+        }
+        $existingSet = array_flip($existing);
+        foreach ($cols as $col => $def) {
+            if (isset($existingSet[$col])) continue;
+            try {
+                $pdo->exec("ALTER TABLE order_links ADD COLUMN `$col` $def");
+            } catch (PDOException $e) {
+                error_log('cotizadorEnsureOrderLinkColumns: ' . $e->getMessage());
+            }
+        }
+    }
+
+    /**
      * Read the configurable delay (hours) before a saved quote is shown to
      * the client. Falls back to 24 if the row is missing.
      */
@@ -35,6 +68,7 @@ if (!defined('IMPORLAN_COTIZADOR_HELPERS_LOADED')) {
      */
     function cotizadorApplyClientVisibility(PDO $pdo, array $links): array {
         if (empty($links)) return $links;
+        cotizadorEnsureOrderLinkColumns($pdo);  // self-heal in case migration hasn't run yet
         $delayHours = cotizadorClientDelayHours($pdo);
         $now = time();
         $orderCustomer = null;  // lazily loaded if we need to send an email
@@ -106,6 +140,7 @@ if (!defined('IMPORLAN_COTIZADOR_HELPERS_LOADED')) {
      * published in this run.
      */
     function cotizadorPublishDue(PDO $pdo): int {
+        cotizadorEnsureOrderLinkColumns($pdo);  // self-heal: cron may run before admin opens Cotizador tab
         $delayHours = cotizadorClientDelayHours($pdo);
         $stmt = $pdo->prepare("
             SELECT ol.*, o.customer_email, o.customer_name, o.order_number

--- a/test/api/settings_api.php
+++ b/test/api/settings_api.php
@@ -468,22 +468,7 @@ function cotizadorSeedDefaults(PDO $pdo): void {
     }
 }
 
-function cotizadorEnsureOrderLinkColumns(PDO $pdo): void {
-    $cols = [
-        'quote_data'           => 'JSON NULL',
-        'quote_total_clp'      => 'DECIMAL(15,0) NULL',
-        'quote_total_usd'      => 'DECIMAL(12,2) NULL',
-        'quote_payments'       => 'JSON NULL',
-        'quote_calculated_at'  => 'TIMESTAMP NULL',
-        'quote_published_at'   => 'TIMESTAMP NULL',
-    ];
-    $existing = $pdo->query("
-        SELECT COLUMN_NAME FROM information_schema.COLUMNS
-        WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'order_links'
-    ")->fetchAll(PDO::FETCH_COLUMN);
-    $existingSet = array_flip($existing);
-    foreach ($cols as $col => $def) {
-        if (isset($existingSet[$col])) continue;
-        $pdo->exec("ALTER TABLE order_links ADD COLUMN `$col` $def");
-    }
-}
+// cotizadorEnsureOrderLinkColumns now lives in cotizador_helpers.php so the
+// cron and lazy-publish paths can self-migrate. Keep the require here for
+// callers that load this file directly.
+require_once __DIR__ . '/cotizador_helpers.php';


### PR DESCRIPTION
## Summary

El cron del cotizador falló con `Unknown column 'ol.quote_calculated_at'` porque la migración de columnas vivía en `settings_api.php` (gatillada solo cuando admin abre el tab Cotizador). El cron corrió antes de eso.

Mueve `cotizadorEnsureOrderLinkColumns` a `cotizador_helpers.php` y la llama defensivamente al inicio de `cotizadorApplyClientVisibility` y `cotizadorPublishDue`. Ahora el cron se auto-cura.

## Test plan

- [ ] Después del deploy: `php /home/wwimpo/public_html/api/cron/cotizador_publish.php` debe imprimir `Published 0 quote(s)` (no error)

https://claude.ai/code/session_01TC2GHyRqyWwuNopX4ArsEE

---
_Generated by [Claude Code](https://claude.ai/code/session_01TC2GHyRqyWwuNopX4ArsEE)_