### PR TITLE
Fix: enviar desglose de cotización en correo inmediato del cotizador

### DIFF
--- a/api/orders_api.php
+++ b/api/orders_api.php
@@ -1324,8 +1324,13 @@ function adminSaveQuote() {
         if ($publishNow) {
             // Fetch the link + customer info and fire the "ready" email synchronously.
             try {
+                // Include quote_data + quote_payments so cotizadorSendReadyEmail
+                // can render the itemized breakdown (Valor Lancha, All-Inclusive,
+                // IVA, Lujo, plan de pagos) — without these columns the email
+                // would compute zeros and dump the whole total into All-Inclusive.
                 $info = $pdo->prepare("
                     SELECT ol.id, ol.year, ol.make, ol.model, ol.quote_total_clp, ol.quote_total_usd,
+                           ol.quote_data, ol.quote_payments,
                            o.customer_email, o.customer_name, o.order_number
                     FROM order_links ol
                     JOIN orders o ON o.id = ol.order_id


### PR DESCRIPTION
## Problema

En el panel admin de Expedientes, al cotizar una lancha (botón `$`) y presionar **"Guardar y enviar ahora"**, el correo al cliente salía con el desglose en cero: todo el total caía en *Servicio All-Inclusive* y el bloque *Plan de pagos* no se renderizaba. El path "Guardar (24 hrs)" sí mostraba los valores correctos porque el cron lee `ol.*`.

## Causa

`adminSaveQuote()` en `api/orders_api.php` hacía un `SELECT` que omitía `ol.quote_data` y `ol.quote_payments` antes de llamar a `cotizadorSendReadyEmail()`. El template necesita esas dos columnas JSON para reconstruir Valor Lancha, IVA Aduanero (CIF × %), Impuesto al Lujo y los 3 pagos.

## Cambio

Una línea en el `SELECT`: ahora trae `ol.quote_data, ol.quote_payments` además de los campos previos. Ambos botones envían el mismo correo con los valores calculados de cada lancha (Valor Lancha, Servicio All-Inclusive, IVA Aduanero, Impuesto al Lujo si aplica, TOTAL, y plan de Pago 1/2/3).

## Test plan

- [ ] Crear cotización en admin → "Guardar y enviar ahora" → revisar que el correo al cliente tenga los valores correctos (no ceros).
- [ ] Crear cotización en admin → "Guardar (24 hrs)" → forzar cron / esperar 24h → revisar que el correo siga llegando con el desglose correcto (regresión).
- [ ] Verificar que el plan de pagos (3 filas) se renderice en ambos correos.

https://claude.ai/code/session_01JXuqw2CLzX5xZFy2p3NoFs

---
_Generated by [Claude Code](https://claude.ai/code/session_01JXuqw2CLzX5xZFy2p3NoFs)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jpchs1/imporlan/pull/508" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->