### PR TITLE
Mobile perf: stop scroll freeze + responsive PRO polish on home

### DIFF
--- a/assets/footer-enhancer.js
+++ b/assets/footer-enhancer.js
@@ -192,6 +192,11 @@
       '  #' + FOOTER_ID + ' .imp-cta-actions{width:100%;}',
       '  #' + FOOTER_ID + ' .imp-cta-actions .imp-btn{flex:1;justify-content:center;}',
       '}',
+      // Mobile perf: drop the heavy blur layers entirely on phones
+      '@media (max-width: 760px){',
+      '  #' + FOOTER_ID + ' .imp-glow-a,#' + FOOTER_ID + ' .imp-glow-b{display:none !important;}',
+      '  #' + FOOTER_ID + ' .imp-cta-strip::before,#' + FOOTER_ID + ' .imp-cta-strip::after{display:none !important;}',
+      '}',
     ].join('\n');
     document.head.appendChild(s);
   }
@@ -466,15 +471,32 @@
     setupNewsletter();
     setupBackToTop();
 
-    // Defensive: if React rerenders and removes our footer or re-adds the old one, fix it
+    // Defensive: if React rerenders and removes our footer or re-adds the old one, fix it.
+    // Throttled via rAF + ignores mutations originating inside our own footer to avoid feedback loops.
     if (window.MutationObserver) {
-      var ob = new MutationObserver(function () {
-        if (!document.getElementById(FOOTER_ID)) {
-          attach();
-          setupNewsletter();
-          setupBackToTop();
+      var pending = 0;
+      var raf = window.requestAnimationFrame || function (f) { return setTimeout(f, 16); };
+      var ob = new MutationObserver(function (mutations) {
+        var ours = document.getElementById(FOOTER_ID);
+        // Skip if every mutation came from inside our footer
+        if (ours) {
+          var allInternal = true;
+          for (var i = 0; i < mutations.length; i++) {
+            var t = mutations[i].target;
+            if (!t || (t !== ours && !ours.contains(t))) { allInternal = false; break; }
+          }
+          if (allInternal) return;
         }
-        hideOldFooter();
+        if (pending) return;
+        pending = raf(function () {
+          pending = 0;
+          if (!document.getElementById(FOOTER_ID)) {
+            attach();
+            setupNewsletter();
+            setupBackToTop();
+          }
+          hideOldFooter();
+        });
       });
       try {
         ob.observe(document.body, { childList: true, subtree: true });

--- a/assets/header-enhancer.js
+++ b/assets/header-enhancer.js
@@ -179,6 +179,11 @@
       '  #' + HEADER_ID + ' .imp-h-tag{display:none;}',
       '  #' + HEADER_ID + ' .imp-h-wrap{padding:0 14px;gap:12px;}',
       '}',
+      // Mobile perf: lighter backdrop-filter to keep scrolling smooth on phones
+      '@media (max-width: 760px){',
+      '  #' + HEADER_ID + '{background:rgba(8,17,33,.92);backdrop-filter:blur(8px);-webkit-backdrop-filter:blur(8px);}',
+      '  #' + BACKDROP_ID + '{backdrop-filter:none !important;-webkit-backdrop-filter:none !important;background:rgba(0,0,0,.65) !important;}',
+      '}',
     ].join('\n');
     document.head.appendChild(s);
   }
@@ -632,14 +637,34 @@
     startUsdTicker();
 
     if (window.MutationObserver) {
-      var ob = new MutationObserver(function () {
-        if (!document.getElementById(HEADER_ID)) {
-          attach();
-          bindScroll();
-          bindDrawer();
-          bindDropdownClose();
+      var pending = 0;
+      var raf = window.requestAnimationFrame || function (f) { return setTimeout(f, 16); };
+      var ob = new MutationObserver(function (mutations) {
+        var ours = document.getElementById(HEADER_ID);
+        var drw = document.getElementById(DRAWER_ID);
+        var bd = document.getElementById(BACKDROP_ID);
+        // Skip if every mutation came from our own header / drawer / backdrop
+        if (ours) {
+          var allInternal = true;
+          for (var i = 0; i < mutations.length; i++) {
+            var t = mutations[i].target;
+            if (!t) continue;
+            var inside = (t === ours || ours.contains(t) || (drw && (t === drw || drw.contains(t))) || (bd && t === bd));
+            if (!inside) { allInternal = false; break; }
+          }
+          if (allInternal) return;
         }
-        hideOldHeader();
+        if (pending) return;
+        pending = raf(function () {
+          pending = 0;
+          if (!document.getElementById(HEADER_ID)) {
+            attach();
+            bindScroll();
+            bindDrawer();
+            bindDropdownClose();
+          }
+          hideOldHeader();
+        });
       });
       try { ob.observe(document.body, { childList: true, subtree: true }); } catch (e) { /* ignore */ }
     }

--- a/assets/plans-enhancer.js
+++ b/assets/plans-enhancer.js
@@ -1,8 +1,9 @@
 /* Imporlan home — Planes de Busqueda PRO enhancer
- * Idempotent. Targets the bundle's plans section by heading text and:
- *  - Tags the section + cards with stable hooks (data-imp-plan, .imp-plans-pro)
- *  - Injects scoped PRO styles (hero pill, glow blobs, gradient borders, hover lift)
- *  - Adds: "Más popular" ribbon, "Mayor valor" ribbon, savings badge, help row
+ * Idempotent + perf-tuned for mobile.
+ *  - Tags the section + cards with stable hooks (data-imp-plan-card, .imp-plans-pro)
+ *  - Injects scoped PRO styles (hero pill, glow blobs (desktop), gradient borders, hover lift)
+ *  - Adds: "Más popular" ribbon, "Premium" ribbon, savings badge, help row
+ *  - Stops listening as soon as the section is fully wired (no permanent observers)
  * Original React buttons / pricing logic are left untouched.
  */
 (function () {
@@ -12,6 +13,7 @@
 
   var STYLE_ID = 'imp-plans-pro-style';
   var SECTION_CLASS = 'imp-plans-pro';
+  var doneFlag = false;
 
   function injectStyle() {
     if (document.getElementById(STYLE_ID)) return;
@@ -19,34 +21,26 @@
     s.id = STYLE_ID;
     s.textContent = [
       '.imp-plans-pro{position:relative;isolation:isolate;padding:56px 16px 64px !important;background:linear-gradient(180deg,#06101e 0%,#0a1628 50%,#06101e 100%) !important;overflow:hidden;}',
-      '.imp-plans-pro::before{content:"";position:absolute;top:-160px;left:-120px;width:420px;height:420px;background:rgba(6,182,212,.16);border-radius:9999px;filter:blur(110px);pointer-events:none;z-index:0;}',
-      '.imp-plans-pro::after{content:"";position:absolute;bottom:-160px;right:-120px;width:380px;height:380px;background:rgba(99,102,241,.14);border-radius:9999px;filter:blur(110px);pointer-events:none;z-index:0;}',
+      '.imp-plans-pro::before{content:"";position:absolute;top:-160px;left:-120px;width:420px;height:420px;background:rgba(6,182,212,.16);border-radius:9999px;filter:blur(110px);pointer-events:none;z-index:0;will-change:auto;}',
+      '.imp-plans-pro::after{content:"";position:absolute;bottom:-160px;right:-120px;width:380px;height:380px;background:rgba(99,102,241,.14);border-radius:9999px;filter:blur(110px);pointer-events:none;z-index:0;will-change:auto;}',
       '.imp-plans-pro > *{position:relative;z-index:1;}',
-      // Hero pill placed above the heading
       '.imp-plans-pill{display:inline-flex;align-items:center;gap:8px;padding:6px 14px;border-radius:9999px;background:rgba(34,211,238,.12);color:#67e8f9;font-size:11.5px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;border:1px solid rgba(34,211,238,.25);margin-bottom:14px;}',
       '.imp-plans-pill .imp-dot{width:6px;height:6px;border-radius:9999px;background:#22d3ee;animation:imp-pulse 1.6s infinite;}',
       '@keyframes imp-pulse{0%,100%{opacity:1}50%{opacity:.4}}',
-      // Title spacing tweaks (do not change colors of bundle headings, just rhythm)
       '.imp-plans-pro h2{margin-top:8px !important;letter-spacing:-.02em !important;}',
-      // Card grid (preserve bundle markup, only restyle whatever wraps cards)
-      '.imp-plans-pro [data-imp-plan-card]{position:relative;border-radius:22px !important;background:linear-gradient(180deg,rgba(15,32,52,.85) 0%,rgba(11,22,38,.95) 100%) !important;border:1px solid rgba(255,255,255,.08) !important;backdrop-filter:blur(10px);box-shadow:0 24px 50px -22px rgba(0,0,0,.55) !important;transition:transform .25s cubic-bezier(.16,1,.3,1),box-shadow .25s,border-color .25s !important;overflow:visible !important;}',
-      '.imp-plans-pro [data-imp-plan-card]:hover{transform:translateY(-4px) !important;border-color:rgba(34,211,238,.32) !important;box-shadow:0 30px 60px -22px rgba(6,182,212,.35) !important;}',
-      // Capitan = Popular: stronger gradient ring + scale
+      '.imp-plans-pro [data-imp-plan-card]{position:relative;border-radius:22px !important;background:linear-gradient(180deg,rgba(15,32,52,.85) 0%,rgba(11,22,38,.95) 100%) !important;border:1px solid rgba(255,255,255,.08) !important;box-shadow:0 24px 50px -22px rgba(0,0,0,.55) !important;transition:transform .25s cubic-bezier(.16,1,.3,1),box-shadow .25s,border-color .25s !important;overflow:visible !important;}',
+      '@media (hover:hover){.imp-plans-pro [data-imp-plan-card]:hover{transform:translateY(-4px) !important;border-color:rgba(34,211,238,.32) !important;box-shadow:0 30px 60px -22px rgba(6,182,212,.35) !important;}}',
       '.imp-plans-pro [data-imp-plan-card="capitan"]{border:1px solid transparent !important;background:linear-gradient(180deg,rgba(15,32,52,.92) 0%,rgba(11,22,38,.98) 100%) padding-box,linear-gradient(135deg,#22d3ee,#6366f1 60%,#8b5cf6) border-box !important;transform:translateY(-2px) scale(1.02) !important;box-shadow:0 30px 60px -22px rgba(6,182,212,.45),0 0 0 1px rgba(34,211,238,.18) inset !important;}',
-      '.imp-plans-pro [data-imp-plan-card="capitan"]:hover{transform:translateY(-6px) scale(1.02) !important;}',
+      '@media (hover:hover){.imp-plans-pro [data-imp-plan-card="capitan"]:hover{transform:translateY(-6px) scale(1.02) !important;}}',
       '.imp-plans-pro [data-imp-plan-card="almirante"]{border:1px solid rgba(168,85,247,.22) !important;}',
-      '.imp-plans-pro [data-imp-plan-card="almirante"]:hover{border-color:rgba(168,85,247,.4) !important;box-shadow:0 30px 60px -22px rgba(139,92,246,.3) !important;}',
-      // Plan name + meta polish
+      '@media (hover:hover){.imp-plans-pro [data-imp-plan-card="almirante"]:hover{border-color:rgba(168,85,247,.4) !important;box-shadow:0 30px 60px -22px rgba(139,92,246,.3) !important;}}',
       '.imp-plans-pro [data-imp-plan-card] h3,.imp-plans-pro [data-imp-plan-card] h4{letter-spacing:-.01em;}',
-      // Ribbon (Capitan)
       '.imp-plans-ribbon{position:absolute;top:-12px;left:50%;transform:translateX(-50%);background:linear-gradient(135deg,#06b6d4,#6366f1);color:#fff;font-size:11px;font-weight:800;letter-spacing:.1em;text-transform:uppercase;padding:6px 14px;border-radius:9999px;box-shadow:0 12px 24px -8px rgba(6,182,212,.55);display:inline-flex;align-items:center;gap:6px;z-index:5;pointer-events:none;}',
       '.imp-plans-ribbon::before{content:"";display:inline-block;width:5px;height:5px;border-radius:9999px;background:#fff;}',
       '.imp-plans-ribbon-premium{background:linear-gradient(135deg,#a855f7,#6366f1);box-shadow:0 12px 24px -8px rgba(168,85,247,.5);}',
-      // Savings badge
       '.imp-plans-saving{display:inline-flex;align-items:center;gap:6px;background:rgba(16,185,129,.15);color:#6ee7b7;border:1px solid rgba(16,185,129,.3);font-size:11px;font-weight:700;letter-spacing:.06em;padding:4px 10px;border-radius:9999px;margin-left:8px;vertical-align:middle;}',
       '.imp-plans-saving svg{flex-shrink:0;}',
-      // Help row at the bottom
-      '.imp-plans-help{max-width:980px;margin:36px auto 0;padding:18px 22px;border-radius:18px;background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.08);backdrop-filter:blur(10px);display:flex;flex-wrap:wrap;align-items:center;justify-content:space-between;gap:14px;color:#cbd5e1;font-size:13.5px;}',
+      '.imp-plans-help{max-width:980px;margin:36px auto 0;padding:18px 22px;border-radius:18px;background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.08);display:flex;flex-wrap:wrap;align-items:center;justify-content:space-between;gap:14px;color:#cbd5e1;font-size:13.5px;}',
       '.imp-plans-help-text{display:flex;align-items:center;gap:10px;flex:1;min-width:240px;}',
       '.imp-plans-help-text strong{color:#fff;font-weight:600;}',
       '.imp-plans-help-icon{width:36px;height:36px;border-radius:12px;background:linear-gradient(135deg,rgba(6,182,212,.2),rgba(99,102,241,.2));display:inline-flex;align-items:center;justify-content:center;color:#22d3ee;flex-shrink:0;}',
@@ -56,20 +50,27 @@
       '.imp-plans-help-btn-wa:hover{background:rgba(34,197,94,.24);color:#bbf7d0;transform:translateY(-1px);}',
       '.imp-plans-help-btn-ghost{background:rgba(255,255,255,.06);color:#e2e8f0;border:1px solid rgba(255,255,255,.12);}',
       '.imp-plans-help-btn-ghost:hover{background:rgba(255,255,255,.10);color:#fff;border-color:rgba(255,255,255,.2);transform:translateY(-1px);}',
-      // Trust mini-row above cards
       '.imp-plans-trust{max-width:980px;margin:14px auto 28px;display:flex;flex-wrap:wrap;justify-content:center;gap:14px 22px;color:#94a3b8;font-size:12.5px;}',
       '.imp-plans-trust-item{display:inline-flex;align-items:center;gap:6px;}',
       '.imp-plans-trust-item svg{color:#22d3ee;flex-shrink:0;}',
-      // Reduce motion
       '@media (prefers-reduced-motion: reduce){',
       '  .imp-plans-pro [data-imp-plan-card]{transition:none !important;}',
       '  .imp-plans-pill .imp-dot{animation:none;}',
       '}',
-      // Responsive
+      // === Mobile perf: drop the heavy blur layers, ease the gradient cards ===
       '@media(max-width:760px){',
+      '  .imp-plans-pro::before,.imp-plans-pro::after{display:none !important;}',
       '  .imp-plans-pro [data-imp-plan-card="capitan"]{transform:none !important;}',
-      '  .imp-plans-pro{padding:40px 12px 48px !important;}',
-      '  .imp-plans-help{padding:16px;}',
+      '  .imp-plans-pro [data-imp-plan-card]{box-shadow:0 12px 26px -16px rgba(0,0,0,.55) !important;}',
+      '  .imp-plans-pro{padding:36px 12px 44px !important;}',
+      '  .imp-plans-help{padding:14px 16px;border-radius:14px;}',
+      '  .imp-plans-ribbon{font-size:10px;padding:5px 11px;top:-10px;}',
+      '  .imp-plans-trust{gap:8px 16px;font-size:12px;margin:10px auto 18px;}',
+      '}',
+      '@media(max-width:420px){',
+      '  .imp-plans-pro{padding:28px 10px 36px !important;}',
+      '  .imp-plans-pill{font-size:10.5px;padding:5px 12px;}',
+      '  .imp-plans-saving{font-size:10px;padding:3px 8px;margin-left:6px;}',
       '}'
     ].join('\n');
     document.head.appendChild(s);
@@ -89,63 +90,30 @@
     for (var i = 0; i < 8 && node; i++) {
       if (!node.parentElement) return node;
       var rect = node.getBoundingClientRect();
-      // Walk up until we find a wrapper that is significantly wider/taller (the cards row container)
       if (rect.height > 320 && rect.width > 600) return node;
       node = node.parentElement;
     }
     return h.parentElement;
   }
 
-  // Heuristic: a "card" is an element that contains the plan name text and at least one price-looking text.
-  function tagCards(section) {
-    var nameMap = [
-      { key: 'fragata', re: /Plan\s+Fragata/i },
-      { key: 'capitan', re: /Plan\s+Capit[áa]n/i },
-      { key: 'almirante', re: /Plan\s+Almirante/i }
-    ];
-    // For each plan name, find the deepest element where it's the only plan name in its subtree, then climb to a stable card-sized ancestor.
-    for (var i = 0; i < nameMap.length; i++) {
-      var info = nameMap[i];
-      var match = findElementContainingExclusive(section, info.re, nameMap);
-      if (!match) continue;
-      var card = climbToCard(match, section);
-      if (card && !card.hasAttribute('data-imp-plan-card')) {
-        card.setAttribute('data-imp-plan-card', info.key);
-        addRibbon(card, info.key);
-        addSavingBadge(card);
+  // TreeWalker-based card finder. Returns the first text node matching `re`,
+  // then climbs to a card-sized ancestor. Cheaper than querySelectorAll('*').
+  function findCardByText(section, re) {
+    var walker = document.createTreeWalker(section, NodeFilter.SHOW_TEXT, {
+      acceptNode: function (n) {
+        return re.test(n.nodeValue || '') ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_REJECT;
       }
-    }
-  }
-
-  function findElementContainingExclusive(root, re, all) {
-    // Pick the deepest element whose textContent matches `re` AND does NOT contain other plan names.
-    var nodes = root.querySelectorAll('*');
-    var best = null;
-    for (var i = 0; i < nodes.length; i++) {
-      var n = nodes[i];
-      var t = n.textContent || '';
-      if (!re.test(t)) continue;
-      var hasOther = false;
-      for (var j = 0; j < all.length; j++) {
-        var o = all[j];
-        if (o.re === re) continue;
-        if (o.re.test(t)) { hasOther = true; break; }
-      }
-      if (hasOther) continue;
-      // Prefer element with smaller text size (more specific)
-      if (!best || (n.textContent && n.textContent.length < best.textContent.length)) {
-        best = n;
-      }
-    }
-    return best;
+    });
+    var node = walker.nextNode();
+    if (!node) return null;
+    return climbToCard(node.parentElement, section);
   }
 
   function climbToCard(start, section) {
     var node = start;
     for (var i = 0; i < 10 && node && node !== section; i++) {
       var rect = node.getBoundingClientRect();
-      // A plan card is typically 240-520px wide and 380-700px tall
-      if (rect.width >= 240 && rect.width <= 560 && rect.height >= 320 && rect.height <= 760) {
+      if (rect.width >= 220 && rect.width <= 580 && rect.height >= 300 && rect.height <= 780) {
         return node;
       }
       node = node.parentElement;
@@ -153,13 +121,33 @@
     return null;
   }
 
+  function tagCards(section) {
+    var keys = [
+      { key: 'fragata', re: /Plan\s+Fragata/i },
+      { key: 'capitan', re: /Plan\s+Capit[áa]n/i },
+      { key: 'almirante', re: /Plan\s+Almirante/i }
+    ];
+    var tagged = 0;
+    for (var i = 0; i < keys.length; i++) {
+      var info = keys[i];
+      if (section.querySelector('[data-imp-plan-card="' + info.key + '"]')) { tagged++; continue; }
+      var card = findCardByText(section, info.re);
+      if (card && !card.hasAttribute('data-imp-plan-card')) {
+        card.setAttribute('data-imp-plan-card', info.key);
+        addRibbon(card, info.key);
+        addSavingBadge(card);
+        tagged++;
+      }
+    }
+    return tagged;
+  }
+
   function addRibbon(card, key) {
     if (card.querySelector('.imp-plans-ribbon')) return;
-    var label = '';
-    var extraClass = '';
-    if (key === 'capitan') { label = 'Más popular'; }
+    var label = '', extraClass = '';
+    if (key === 'capitan') label = 'Más popular';
     else if (key === 'almirante') { label = 'Premium'; extraClass = 'imp-plans-ribbon-premium'; }
-    else { return; }
+    else return;
     var span = document.createElement('span');
     span.className = 'imp-plans-ribbon ' + extraClass;
     span.textContent = label;
@@ -168,32 +156,27 @@
 
   function addSavingBadge(card) {
     if (card.querySelector('.imp-plans-saving')) return;
-    // Find "Antes $X" text inside the card
     var walker = document.createTreeWalker(card, NodeFilter.SHOW_TEXT, null);
-    var beforeAmount = null, currentAmount = null;
-    var anchor = null;
-    var node;
+    var beforeAmount = null, anchor = null, node;
     while ((node = walker.nextNode())) {
-      var t = node.nodeValue || '';
-      var m = t.match(/Antes\s*\$([\d.\,]+)/i);
+      var m = (node.nodeValue || '').match(/Antes\s*\$([\d.,]+)/i);
       if (m && !beforeAmount) {
         beforeAmount = parseInt(m[1].replace(/[\.,]/g, ''), 10);
         anchor = node.parentElement;
+        break;
       }
     }
     if (!beforeAmount) return;
-    // Find current price (first $X in card that isn't "Antes")
-    var priceMatch = (card.textContent || '').match(/\$([\d.\,]+)\s*CLP/i);
-    if (priceMatch) currentAmount = parseInt(priceMatch[1].replace(/[\.,]/g, ''), 10);
-    if (!currentAmount || !beforeAmount || currentAmount >= beforeAmount) return;
+    var priceMatch = (card.textContent || '').match(/\$([\d.,]+)\s*CLP/i);
+    if (!priceMatch) return;
+    var currentAmount = parseInt(priceMatch[1].replace(/[\.,]/g, ''), 10);
+    if (!currentAmount || currentAmount >= beforeAmount) return;
     var pct = Math.round((1 - currentAmount / beforeAmount) * 100);
     if (pct < 5) return;
     var badge = document.createElement('span');
     badge.className = 'imp-plans-saving';
     badge.innerHTML = '<svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83"/></svg>Ahorro ' + pct + '%';
-    if (anchor && anchor.parentElement) {
-      anchor.appendChild(badge);
-    }
+    if (anchor && anchor.parentElement) anchor.appendChild(badge);
   }
 
   function ensureHeroPill(section, heading) {
@@ -205,9 +188,7 @@
     pill.style.textAlign = 'center';
     pill.style.margin = '0 auto 10px';
     pill.style.maxWidth = 'fit-content';
-    if (heading && heading.parentElement) {
-      heading.parentElement.insertBefore(pill, heading);
-    }
+    if (heading && heading.parentElement) heading.parentElement.insertBefore(pill, heading);
   }
 
   function ensureTrustRow(section, heading) {
@@ -218,16 +199,13 @@
       '<span class="imp-plans-trust-item"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>Búsqueda en concesionarios verificados USA</span>' +
       '<span class="imp-plans-trust-item"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>Reportes en 7, 14 o 21 días</span>' +
       '<span class="imp-plans-trust-item"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 12l2 2 4-4M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>Cancelá cuando quieras</span>';
-    // Insert after any existing subtitle paragraph that follows the heading
     var anchor = heading;
     var sibling = heading && heading.nextElementSibling;
     while (sibling && (sibling.tagName === 'P' || sibling.tagName === 'DIV') && sibling.children.length < 3) {
       anchor = sibling;
       sibling = sibling.nextElementSibling;
     }
-    if (anchor && anchor.parentElement) {
-      anchor.parentElement.insertBefore(row, anchor.nextSibling);
-    }
+    if (anchor && anchor.parentElement) anchor.parentElement.insertBefore(row, anchor.nextSibling);
   }
 
   function ensureHelpRow(section) {
@@ -253,6 +231,7 @@
   }
 
   function apply() {
+    if (doneFlag) return true;
     var heading = findHeading();
     if (!heading) return false;
     var section = findSectionFromHeading(heading);
@@ -261,22 +240,42 @@
     injectStyle();
     ensureHeroPill(section, heading);
     ensureTrustRow(section, heading);
-    tagCards(section);
+    var tagged = tagCards(section);
     ensureHelpRow(section);
-    return true;
+    if (tagged >= 3 && section.querySelector('.imp-plans-help')) {
+      doneFlag = true;
+    }
+    return doneFlag;
   }
 
   function start() {
-    var ok = apply();
-    var attempts = 0;
-    var iv = setInterval(function () {
-      attempts++;
-      if (apply() || attempts >= 30) clearInterval(iv);
-    }, 300);
-    var mo = new MutationObserver(function () { apply(); });
-    mo.observe(document.body || document.documentElement, { childList: true, subtree: true });
-    window.addEventListener('load', apply);
-    return ok;
+    if (apply()) return;
+    var iv, mo, hardStop, pendingFrame = 0;
+
+    function teardown() {
+      if (iv) { clearInterval(iv); iv = null; }
+      if (mo) { try { mo.disconnect(); } catch (e) {} mo = null; }
+      if (hardStop) { clearTimeout(hardStop); hardStop = null; }
+    }
+
+    iv = setInterval(function () {
+      if (apply()) teardown();
+    }, 500);
+
+    if (window.MutationObserver) {
+      mo = new MutationObserver(function () {
+        if (doneFlag) { teardown(); return; }
+        if (pendingFrame) return;
+        pendingFrame = (window.requestAnimationFrame || function (f) { return setTimeout(f, 16); })(function () {
+          pendingFrame = 0;
+          if (apply()) teardown();
+        });
+      });
+      try { mo.observe(document.body || document.documentElement, { childList: true, subtree: true }); } catch (e) {}
+    }
+
+    // Hard cap: never run longer than 12s regardless of result.
+    hardStop = setTimeout(teardown, 12000);
   }
 
   if (document.readyState === 'loading') {

--- a/index.html
+++ b/index.html
@@ -349,9 +349,9 @@
     <script defer src="/assets/proceso-compra-section.js?v=20260330"></script>
     <script defer src="/assets/mobile-ux-optimizer.js?v=20260228"></script>
     <script defer src="/assets/text-reducer.js?v=20260304"></script>
-    <script defer src="/assets/header-enhancer.js?v=20260509a"></script>
-    <script defer src="/assets/footer-enhancer.js?v=20260509b"></script>
-    <script defer src="/assets/plans-enhancer.js?v=20260509a"></script>
+    <script defer src="/assets/header-enhancer.js?v=20260509c"></script>
+    <script defer src="/assets/footer-enhancer.js?v=20260509c"></script>
+    <script defer src="/assets/plans-enhancer.js?v=20260509c"></script>
     <!-- Cross-domain partner links are now rendered by footer-enhancer.js as part of the redesigned footer -->
   </body>
 </html>


### PR DESCRIPTION
## Summary

Diagnoses and fixes the **mobile scroll freeze** on the home, plus general responsive polish.

### Root cause
`plans-enhancer.js` set up a `MutationObserver` on `document.body` with `subtree: true` and never disconnected it. Every DOM mutation triggered `apply()`, which ran a `querySelectorAll('*')` + `getBoundingClientRect()` walk. Combined with `filter: blur(110px)` blob layers and `backdrop-filter: blur(10px)` on the cards, the mobile compositor stalled and scroll became unresponsive.

### Fix
**plans-enhancer.js**
- `doneFlag` short-circuit; `teardown()` disconnects the MutationObserver + clears the interval as soon as the section + 3 cards + help row are wired (or after a 12s hard cap).
- MutationObserver callback throttled via `requestAnimationFrame`.
- `findCardByText` uses a `TreeWalker` filtered at iteration time instead of `querySelectorAll('*')`.
- Mobile (≤ 760px): hides the two `::before/::after` blob layers, drops hover scale on Capitan, lighter shadows, smaller paddings/ribbons/badges.
- Removed `backdrop-filter` on cards + help row.
- Hover styles wrapped in `@media (hover: hover)` so touch devices skip the transform/shadow updates.

**footer-enhancer.js**
- MutationObserver throttled via rAF; bails out when every mutation came from inside our own footer (was self-feeding).
- `@media (max-width: 760px)` hides `.imp-glow-a/.imp-glow-b` and the CTA strip radial gradient pseudo-elements.

**header-enhancer.js**
- Same throttle + ignore-self treatment for the MutationObserver (also considers the drawer/backdrop as our own).
- `@media (max-width: 760px)` reduces the header `backdrop-filter` from `blur(18px) saturate(180%)` to `blur(8px)` and removes the drawer backdrop blur entirely (solid rgba instead).

**index.html**
- Cache bust: header/footer/plans → `?v=20260509c`.

## Test plan
- [ ] Open the home on a real phone — scrolling stays smooth from top to footer, including over the plans section.
- [ ] Plans section still shows: pill, trust row, Capitan ribbon, Almirante "Premium" ribbon, savings badges, help row.
- [ ] Header still hides the bundle's old header; drawer opens and closes; USD ticker still updates.
- [ ] Footer still shows the redesigned grid + back-to-top.
- [ ] No console errors.
- [ ] Lighthouse Mobile Performance shouldn't regress; LCP/INP should improve.

https://claude.ai/code/session_01GqCGWuyhatt6tWJcscpwrC

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqCGWuyhatt6tWJcscpwrC)_