### PR TITLE
Fix mobile scroll freeze: kill marquee setInterval(20ms), use rAF + IO

### DIFF
--- a/assets/marketplace-section.js
+++ b/assets/marketplace-section.js
@@ -475,31 +475,59 @@
 
   function startCarouselAutoScroll(track) {
     if (!track || !track.children.length) return;
+    // Disable auto-scroll on touch devices: it causes scroll-jank, and users
+    // already swipe horizontally. Visibility-pause + rAF on desktop only.
+    var isTouch = (window.matchMedia && window.matchMedia('(hover: none)').matches) ||
+                  ('ontouchstart' in window && (!window.matchMedia || !window.matchMedia('(hover: hover)').matches));
+    if (isTouch) return;
+
     var paused = false;
+    var visible = true;
     var direction = 1;
+    var rafId = 0;
+    var lastTs = 0;
+    // 1px every ~20ms ≈ 50px/s. Use time-based delta so the speed is identical
+    // regardless of frame rate, and the work is bounded by display refresh.
+    var pxPerSecond = 50;
 
     track.style.scrollBehavior = 'auto';
 
-    track.addEventListener('mouseenter', function() { paused = true; });
-    track.addEventListener('mouseleave', function() { paused = false; });
-    track.addEventListener('touchstart', function() { paused = true; }, {passive: true});
-    track.addEventListener('touchend', function() {
-      setTimeout(function() { paused = false; }, 3000);
+    track.addEventListener('mouseenter', function () { paused = true; });
+    track.addEventListener('mouseleave', function () { paused = false; });
+
+    if (window.IntersectionObserver) {
+      var io = new IntersectionObserver(function (entries) {
+        for (var i = 0; i < entries.length; i++) visible = entries[i].isIntersecting;
+      }, { threshold: 0.1 });
+      io.observe(track);
+    }
+    document.addEventListener('visibilitychange', function () {
+      if (document.hidden) { visible = false; } else if (window.IntersectionObserver) {
+        // re-evaluate on next frame via the IO entry already scheduled
+      } else { visible = true; }
     });
 
-    setInterval(function() {
-      if (paused) return;
-      var maxScroll = track.scrollWidth - track.clientWidth;
-      if (maxScroll <= 0) return;
-
-      track.scrollLeft += direction;
-
-      if (track.scrollLeft >= maxScroll - 1) {
-        direction = -1;
-      } else if (track.scrollLeft <= 0) {
-        direction = 1;
+    var maxScroll = 0;
+    function tick(ts) {
+      if (!paused && visible) {
+        if (lastTs) {
+          var dt = ts - lastTs;
+          maxScroll = track.scrollWidth - track.clientWidth;
+          if (maxScroll > 0) {
+            var step = direction * (pxPerSecond * dt / 1000);
+            var next = track.scrollLeft + step;
+            if (next >= maxScroll - 1) { direction = -1; next = maxScroll; }
+            else if (next <= 0) { direction = 1; next = 0; }
+            track.scrollLeft = next;
+          }
+        }
+        lastTs = ts;
+      } else {
+        lastTs = 0;
       }
-    }, 20);
+      rafId = requestAnimationFrame(tick);
+    }
+    rafId = requestAnimationFrame(tick);
   }
 
   onReady(function() {

--- a/index.html
+++ b/index.html
@@ -339,7 +339,7 @@
     <script defer src="/assets/imporlan-enhancements.js?v=20260301a"></script>
     <script defer src="/assets/dolar-updater.js?v=20260122"></script>
     <script defer src="/assets/seo-sections.js?v=20260324b"></script>
-    <script defer src="/assets/marketplace-section.js?v=20260227b"></script>
+    <script defer src="/assets/marketplace-section.js?v=20260509a"></script>
     <script defer src="/assets/seo-pages-section.js?v=20260304b"></script>
     <script defer src="/assets/inspeccion-precompra-section.js?v=20260324"></script>
     <script defer src="/assets/transparencia-section.js?v=20260427b"></script>


### PR DESCRIPTION
## Summary

Real culprit of the home mobile freeze. The "Top Oportunidades USA" carousel in `marketplace-section.js` ran `setInterval(fn, 20)` — 50 ticks/s — and inside each tick read `scrollWidth`/`clientWidth` then wrote `scrollLeft`. That's a layout-thrash loop that never stopped, ran even when the carousel was off-screen, and on mobile compounded with the rest of the page's work to lock scrolling.

### Fix
- Convert the marquee to `requestAnimationFrame` with a time-based delta (~50 px/s) so speed is identical at 60Hz and 120Hz.
- **Disable auto-scroll on touch devices** via `matchMedia('(hover: none)')` / `('ontouchstart' in window)` — phones already swipe the carousel by hand, the marquee only added jank.
- Pause when off-screen (`IntersectionObserver`) and when the tab is hidden (`document.visibilitychange`).
- `index.html`: bump `marketplace-section.js` to `?v=20260509a`.

## Test plan
- [ ] Open `https://www.imporlan.cl/` on a real phone — scroll from top to bottom is smooth, no lock.
- [ ] On desktop, the marketplace carousel still auto-scrolls and pauses on `mouseenter`.
- [ ] On desktop, scrolling away from the carousel pauses the auto-scroll (verify in Performance panel: no rAF callbacks for the marquee while off-screen).
- [ ] No console errors.

https://claude.ai/code/session_01GqCGWuyhatt6tWJcscpwrC

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqCGWuyhatt6tWJcscpwrC)_