### PR TITLE
Home mobile polish: bundle hero ("Importa tu lancha ideal desde USA")

### DIFF
--- a/assets/imporlan-enhancements.js
+++ b/assets/imporlan-enhancements.js
@@ -26,9 +26,17 @@
       '  form button[type="submit"],form .submit,form .btn-primary{min-height:48px;width:100%;font-size:15px;}',
       // Bundle hero CTAs may be small on mobile — bump to 48px tap target
       '  a[role="button"],button{min-height:44px;}',
+      // Bundle hero ("Importa tu lancha ideal desde USA"): h1 keeps Tailwind
+      // text-4xl (2.25rem) by default, which wraps awkwardly on 360px phones.
+      // Target precisely via :has(.gradient-text) so we never hit other h1s.
+      '  h1:has(> .gradient-text){font-size:1.85rem !important;line-height:1.15 !important;margin-bottom:14px !important;}',
+      '  h1:has(> .gradient-text) + p{font-size:0.95rem !important;margin-bottom:20px !important;}',
+      // Hero CTA pair (.gradient-cyan + sibling outline button): full-width on mobile
+      '  .gradient-cyan{padding:14px 22px !important;font-size:0.95rem !important;width:100% !important;}',
       '}',
       '@media (max-width: 420px){',
       '  .cotizacion-info-text{font-size:12.5px !important;padding:9px 10px !important;}',
+      '  h1:has(> .gradient-text){font-size:1.55rem !important;}',
       '}'
     ].join('\n');
     document.head.appendChild(s);

--- a/index.html
+++ b/index.html
@@ -336,7 +336,7 @@
       </div>
     </noscript>
     <script defer src="/assets/webpay-override.js?v=20260122"></script>
-    <script defer src="/assets/imporlan-enhancements.js?v=20260509f"></script>
+    <script defer src="/assets/imporlan-enhancements.js?v=20260509g"></script>
     <script defer src="/assets/dolar-updater.js?v=20260122"></script>
     <script defer src="/assets/seo-sections.js?v=20260509f"></script>
     <script defer src="/assets/marketplace-section.js?v=20260509f"></script>


### PR DESCRIPTION
## Summary
Follow-up to #523 covering the home page hero rendered by the React bundle (`Importa tu lancha ideal desde USA`). Tailwind's default `text-4xl` (2.25rem) wraps awkwardly on 360px phones, and we couldn't touch the bundle directly — so this PR extends `injectMobilePolish()` in `imporlan-enhancements.js` with media rules that target the hero via `h1:has(> .gradient-text)`. The `gradient-text` span is unique to that h1, so we never hit unrelated headings.

### Changes
**`@media (max-width: 640px)`:**
- Hero h1 → `1.85rem`, `line-height: 1.15`, `mb: 14px`
- Hero subtitle (`h1 + p`) → `0.95rem`, `mb: 20px`
- Hero CTAs (`.gradient-cyan`) → `padding: 14px 22px`, `font-size: 0.95rem`, `width: 100%`

**`@media (max-width: 420px)`:**
- Hero h1 → `1.55rem`

### Browser support note
`:has()` works on all modern browsers we target (Chrome 105+, Safari 15.4+, Firefox 121+). On legacy browsers the rule is silently ignored and Tailwind defaults apply — safe fallback.

### Files
- `assets/imporlan-enhancements.js` — added 4 lines to the existing mobile polish stylesheet
- `index.html` — bumped to `?v=20260509g`

## Test plan
- [ ] Open home on a 360-414px phone. Hero h1 fits on 1-2 lines, no awkward wrapping.
- [ ] CTAs `Cotizar` y `Ver Catálogo` ocupan ancho completo, tap target cómodo.
- [ ] Desktop ≥768px: cero cambios visuales (las @media rules no aplican).
- [ ] Inspector: revisar que `h1:has(> .gradient-text)` matchea solo el hero.

https://claude.ai/code/session_01GqCGWuyhatt6tWJcscpwrC

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqCGWuyhatt6tWJcscpwrC)_