### PR TITLE
Cotizador Online: connect Home → Panel + responsive UI/UX polish

### DIFF
--- a/assets/imporlan-enhancements.js
+++ b/assets/imporlan-enhancements.js
@@ -33,10 +33,33 @@
       '  h1:has(> .gradient-text) + p{font-size:0.95rem !important;margin-bottom:20px !important;}',
       // Hero CTA pair (.gradient-cyan + sibling outline button): full-width on mobile
       '  .gradient-cyan{padding:14px 22px !important;font-size:0.95rem !important;width:100% !important;}',
+      // ===== HOME COTIZADOR ONLINE (#cotizar) =====
+      // Section vertical padding (py-24 = 96px) is too tall on phones.
+      '  section#cotizar{padding-top:56px !important;padding-bottom:56px !important;}',
+      // h2 "Cotiza tu Lancha" (text-3xl sm:text-4xl)
+      '  #cotizar h2{font-size:1.7rem !important;line-height:1.2 !important;}',
+      // h3 "Solicitar Cotizacion" (text-2xl)
+      '  #cotizar h3{font-size:1.2rem !important;}',
+      '  #cotizar p{font-size:0.95rem !important;}',
+      // White form panel: tighter padding so inputs have more horizontal room
+      '  #cotizar .glass-white{padding:20px !important;border-radius:18px !important;}',
+      // Stack the two-col rows in the FORM (Nombre+Email, Telefono+Pais).
+      // Selector is scoped to the form so the LEFT column "Portales" 2-col
+      // layout (icons + label) is preserved.
+      '  #cotizar form .grid.grid-cols-2{grid-template-columns:1fr !important;gap:12px !important;}',
+      // Submit "Solicitar Cotizacion" button: tighter than Tailwind py-6
+      '  #cotizar form button[type="submit"]{padding-top:14px !important;padding-bottom:14px !important;font-size:1rem !important;}',
+      // Reduce gap between left/right blocks (was gap-12 = 48px)
+      '  #cotizar .gap-12{gap:32px !important;}',
       '}',
       '@media (max-width: 420px){',
       '  .cotizacion-info-text{font-size:12.5px !important;padding:9px 10px !important;}',
       '  h1:has(> .gradient-text){font-size:1.55rem !important;}',
+      '  section#cotizar{padding-top:40px !important;padding-bottom:40px !important;}',
+      '  #cotizar h2{font-size:1.4rem !important;}',
+      '  #cotizar h3{font-size:1.1rem !important;}',
+      '  #cotizar .glass-white{padding:16px !important;border-radius:14px !important;}',
+      '  #cotizar form button[type="submit"]{font-size:0.95rem !important;}',
       '}'
     ].join('\n');
     document.head.appendChild(s);

--- a/index.html
+++ b/index.html
@@ -336,7 +336,7 @@
       </div>
     </noscript>
     <script defer src="/assets/webpay-override.js?v=20260122"></script>
-    <script defer src="/assets/imporlan-enhancements.js?v=20260509g"></script>
+    <script defer src="/assets/imporlan-enhancements.js?v=20260509h"></script>
     <script defer src="/assets/dolar-updater.js?v=20260122"></script>
     <script defer src="/assets/seo-sections.js?v=20260509f"></script>
     <script defer src="/assets/marketplace-section.js?v=20260509f"></script>

--- a/panel/assets/cotizador-bridge.js
+++ b/panel/assets/cotizador-bridge.js
@@ -1,0 +1,159 @@
+/**
+ * Cotizador Bridge: Home -> Panel
+ *
+ * The home React bundle saves the quotation form to
+ *   localStorage.imporlan_quotation_data = {name,email,phone,country,links,timestamp,type}
+ * and redirects to /panel/. After the user logs in/registers, this script
+ * navigates to the Cotizador Online section (#quotation) and pre-fills the
+ * link inputs so they can review and pay.
+ *
+ * Flow:
+ *   1. On every panel page load, read imporlan_quotation_data.
+ *   2. Wait until the user is authenticated (imporlan_token exists).
+ *   3. Force the hash to #quotation (one time, only if not already there).
+ *   4. Poll for the link inputs and set their values via the React-compatible
+ *      setter, then clear the payload so it doesn't fire twice.
+ *   5. Show a confirmation toast.
+ */
+(function () {
+  'use strict';
+
+  var KEY = 'imporlan_quotation_data';
+  var TOKEN_KEY = 'imporlan_token';
+  var POLL_MS = 500;
+  var MAX_TICKS = 240; // 2 minutes
+
+  function readPayload() {
+    try {
+      var raw = localStorage.getItem(KEY);
+      if (!raw) return null;
+      var data = JSON.parse(raw);
+      if (!data || !Array.isArray(data.links)) return null;
+      var links = data.links.filter(function (s) { return typeof s === 'string' && s.trim(); });
+      if (!links.length) return null;
+      data.links = links;
+      return data;
+    } catch (e) {
+      return null;
+    }
+  }
+
+  function clearPayload() {
+    try { localStorage.removeItem(KEY); } catch (e) {}
+    try { sessionStorage.removeItem(KEY); } catch (e) {}
+  }
+
+  function isAuthed() {
+    try { return !!localStorage.getItem(TOKEN_KEY); } catch (e) { return false; }
+  }
+
+  function setReactInputValue(input, value) {
+    var setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set;
+    setter.call(input, value);
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+  }
+
+  function findLinkInputs() {
+    // Panel cotizador inputs share placeholder "https://www.boattrader.com/boat/...".
+    var nodes = document.querySelectorAll('input[placeholder*="boattrader.com"]');
+    if (nodes.length) return Array.from(nodes);
+    // Fallback only when we are on the cotizador route.
+    if (window.location.hash.indexOf('quotation') === -1) return [];
+    var fallback = document.querySelectorAll('input.font-mono, input[placeholder^="https://"]');
+    return Array.from(fallback).filter(function (n) { return n.type !== 'email'; });
+  }
+
+  var hashForced = false;
+  function ensureHash() {
+    if (hashForced) return;
+    if (window.location.hash.indexOf('quotation') !== -1) { hashForced = true; return; }
+    hashForced = true;
+    try {
+      history.replaceState(null, '', window.location.pathname + '#quotation');
+      window.dispatchEvent(new HashChangeEvent('hashchange'));
+    } catch (e) {
+      window.location.hash = '#quotation';
+    }
+  }
+
+  var toastShown = false;
+  function showToast(msg) {
+    if (toastShown) return;
+    toastShown = true;
+    if (!document.getElementById('imp-bridge-toast-style')) {
+      var s = document.createElement('style');
+      s.id = 'imp-bridge-toast-style';
+      s.textContent = '@keyframes imp-bridge-pop{from{transform:translate(-50%,-12px);opacity:0}to{transform:translate(-50%,0);opacity:1}}';
+      document.head.appendChild(s);
+    }
+    var t = document.createElement('div');
+    t.id = 'imp-bridge-toast';
+    t.textContent = msg;
+    t.style.cssText = [
+      'position:fixed', 'left:50%', 'top:18px', 'transform:translateX(-50%)',
+      'background:linear-gradient(135deg,#059669,#10b981)', 'color:#fff',
+      'padding:12px 18px', 'border-radius:12px',
+      'box-shadow:0 8px 24px rgba(0,0,0,0.25)', 'z-index:99999',
+      'font-weight:600', 'font-size:14px',
+      'max-width:90vw', 'text-align:center',
+      'animation:imp-bridge-pop .35s ease-out'
+    ].join(';');
+    document.body.appendChild(t);
+    setTimeout(function () {
+      t.style.transition = 'opacity .4s';
+      t.style.opacity = '0';
+      setTimeout(function () { if (t.parentNode) t.parentNode.removeChild(t); }, 500);
+    }, 5000);
+  }
+
+  // Some Cotizador implementations seed slot 0 with a demo URL. If our payload
+  // covers fewer slots than exist, blank out the leftover demo so the user
+  // doesn't pay for it by mistake.
+  var DEMO_MARKER = 'boattrader.com/boat/2021-cobalt';
+  function clearDemoSlots(inputs, fromIndex) {
+    for (var i = fromIndex; i < inputs.length; i++) {
+      var v = inputs[i].value || '';
+      if (v.indexOf(DEMO_MARKER) !== -1) setReactInputValue(inputs[i], '');
+    }
+  }
+
+  function tryRestore(payload) {
+    if (!isAuthed()) return false;
+    ensureHash();
+    var inputs = findLinkInputs();
+    if (!inputs.length) return false;
+
+    payload.links.forEach(function (link, i) {
+      if (i < inputs.length) setReactInputValue(inputs[i], link);
+    });
+    clearDemoSlots(inputs, payload.links.length);
+
+    // Bring the form into view so the user immediately sees the prefilled state.
+    if (inputs[0] && inputs[0].scrollIntoView) {
+      try { inputs[0].scrollIntoView({ behavior: 'smooth', block: 'center' }); } catch (e) {}
+    }
+
+    showToast('Tus links de cotizacion estan listos. Revisa y procede al pago.');
+    clearPayload();
+    return true;
+  }
+
+  function start() {
+    var payload = readPayload();
+    if (!payload) return;
+    var ticks = 0;
+    var iv = setInterval(function () {
+      ticks++;
+      var done = false;
+      try { done = tryRestore(payload); } catch (e) { /* keep polling */ }
+      if (done || ticks >= MAX_TICKS) clearInterval(iv);
+    }, POLL_MS);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', start);
+  } else {
+    start();
+  }
+})();

--- a/panel/index.html
+++ b/panel/index.html
@@ -84,5 +84,7 @@
     <script src="/panel/assets/documents-enhancer.js?v=1" defer></script>
     <!-- Messages Section Enhancer -->
     <script src="/panel/assets/messages-enhancer.js?v=1" defer></script>
+    <!-- Cotizador Bridge: restore links coming from the home cotizador form -->
+    <script src="/panel/assets/cotizador-bridge.js?v=20260509a" defer></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary

Two related fixes for the **Cotizador Online**: connect the home form to the panel form (so the user's links carry over after login/registro), and polish the home form's responsive UI/UX.

### 1. Home → Panel link bridge (was broken end-to-end)

**Bug found during audit:**
- Home React bundle saves to `localStorage.imporlan_quotation_data` then redirects to `/panel/` ✅
- The existing `restoreCotizadorLinks()` in `imporlan-enhancements.js` was reading the **wrong key** (`imporlan_cotizador_links`) and was **not loaded on `/panel/` at all** (panel/index.html doesn't include the home enhancer)
- Net effect: user fills the form, clicks "Solicitar Cotización", logs in… and the panel shows the demo Boattrader URL as if nothing happened

**Fix:** dedicated panel-side script `panel/assets/cotizador-bridge.js`:

1. Reads `imporlan_quotation_data` from localStorage on every panel page load.
2. Polls every 500ms (max 2 min) until `imporlan_token` exists (= logged in / registered).
3. Forces `window.location.hash = '#quotation'` (via `replaceState` + manual `hashchange` dispatch) so the panel navigates to the Cotizador Online section.
4. Once link inputs appear (`placeholder *= "boattrader.com"`), writes each saved link via the React-compatible value setter, smooth-scrolls to the first input, blanks any leftover demo slot, and shows a green confirmation toast.
5. Clears the payload so it never re-fires.

### 2. Home Cotizador responsive UI/UX polish

Scoped `@media` rules under `#cotizar` (added to `injectMobilePolish()` in `imporlan-enhancements.js`):

| Issue | Before (Tailwind default) | After (≤640px / ≤420px) |
|---|---|---|
| Section padding | `py-24` (96px) | `56px` / `40px` |
| Form panel padding | `p-8` (32px) | `20px` / `16px` |
| `Nombre+Email` row | `grid-cols-2` even on phones | **stacks 1fr** |
| `Teléfono+País` row | `grid-cols-2` even on phones | **stacks 1fr** |
| h2 / h3 | `text-3xl` / `text-2xl` | `1.7rem 1.4rem` / `1.2rem 1.1rem` |
| Submit button padding | `py-6` (24px) | `14px` |
| Left/right gap | `gap-12` (48px) | `32px` |

The form-only scoping (`#cotizar form .grid.grid-cols-2`) deliberately leaves the left column "Portales Recomendados" 2-col card grid alone — it's icons+label, fine on phones.

### Files
- `panel/assets/cotizador-bridge.js` *(new, ~150 lines)*
- `panel/index.html` — adds the bridge script
- `assets/imporlan-enhancements.js` — `#cotizar` mobile rules
- `index.html` — bumped to `?v=20260509h`

## Test plan
- [ ] Home en mobile (360-414px): form columns se apilan, padding más compacto, h2/h3 más chicos.
- [ ] Llenar form en home con 1-3 links → click "Solicitar Cotización" → redirect a `/panel/`.
- [ ] Si **no logueado**: aparece login screen. Después de login → panel navega solo a `#quotation` y los inputs aparecen pre-llenados con los links del home.
- [ ] Si **ya logueado**: el panel salta directo a `#quotation` con los inputs pre-llenados.
- [ ] Toast verde aparece arriba: "Tus links de cotización están listos. Revisa y procede al pago."
- [ ] El demo seed link de Cobalt (slot 0) se limpia si el usuario sólo llenó algunos slots.
- [ ] Refrescar el panel: NO se vuelve a disparar el bridge (payload ya borrado).
- [ ] Entrar a /panel/ sin venir del home: bridge no hace nada.

https://claude.ai/code/session_01GqCGWuyhatt6tWJcscpwrC

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqCGWuyhatt6tWJcscpwrC)_