### PR TITLE
Tracking bridge v2: vessel_detail + vessel_positions filter

### DIFF
--- a/panel/user/assets/tracking-bridge.js
+++ b/panel/user/assets/tracking-bridge.js
@@ -145,16 +145,57 @@
 
   function fixVessel(v) {
     if (!v || typeof v !== 'object') return;
+    // vessel_detail responses don't carry top-level lat/lon -- only inside
+    // current_position. Hoist them so the resolver sees the real AIS point;
+    // otherwise it always falls through to the time-projection branch and
+    // drags MSC Pamela / Maersk Seletar (already on route) off into Chile.
+    if ((v.lat == null || v.lat === '') && v.current_position && v.current_position.lat != null) {
+      v.lat = v.current_position.lat;
+    }
+    if ((v.lon == null || v.lon === '') && v.current_position && v.current_position.lon != null) {
+      v.lon = v.current_position.lon;
+    }
     var r = resolveVesselPosition(v);
     if (!r) return; // unknown ports, leave as-is
     v.lat = String(r.lat);
     v.lon = String(r.lon);
     if (r.arrived) v.status = 'arrived';
-    // vessel_detail also has a current_position object
     if (v.current_position && typeof v.current_position === 'object') {
       v.current_position.lat = r.lat;
       v.current_position.lon = r.lon;
     }
+  }
+
+  // ============================================
+  // vessel_positions track history filter
+  // ----------------------------------------------
+  // The AIS feed returns the ship's full historical track. For some vessels
+  // that includes Europe/Africa coordinates from before/after the booked
+  // USA -> Chile transit (MSC Pamela has Hamburg/Antwerp positions; CMA CGM
+  // Thalassa has positions off Portugal). The /panel/user/ React bundle
+  // draws a polyline through the entire track, producing visible Atlantic
+  // crossings on the map.
+  //
+  // We constrain the polyline to the Americas + Pacific corridor by dropping
+  // any position whose (lat, lon) falls outside a generous bounding box that
+  // still covers every plausible US-port-to-Chile route.
+  // ============================================
+  var CORRIDOR_LON_MIN = -135;  // West coast US (~-122) with margin
+  var CORRIDOR_LON_MAX = -65;   // East coast US (~-74) with margin
+  var CORRIDOR_LAT_MIN = -40;   // South of Valparaiso (-33)
+  var CORRIDOR_LAT_MAX = 52;    // North of New York (40) / Seattle (47)
+  function inCorridor(lat, lon) {
+    return lon >= CORRIDOR_LON_MIN && lon <= CORRIDOR_LON_MAX &&
+           lat >= CORRIDOR_LAT_MIN && lat <= CORRIDOR_LAT_MAX;
+  }
+  function filterPositions(positions) {
+    if (!Array.isArray(positions)) return positions;
+    return positions.filter(function (p) {
+      var lat = parseFloat(p.lat);
+      var lon = parseFloat(p.lon != null ? p.lon : p.lng);
+      if (isNaN(lat) || isNaN(lon)) return false;
+      return inCorridor(lat, lon);
+    });
   }
 
   function shouldIntercept(url) {
@@ -163,7 +204,8 @@
     }
     if (url.indexOf('tracking_api.php') === -1) return false;
     return url.indexOf('action=featured') !== -1 ||
-           url.indexOf('action=vessel_detail') !== -1;
+           url.indexOf('action=vessel_detail') !== -1 ||
+           url.indexOf('action=vessel_positions') !== -1;
   }
 
   // ============================================
@@ -186,6 +228,9 @@
           if (data && data.success) {
             if (Array.isArray(data.vessels)) data.vessels.forEach(fixVessel);
             if (data.vessel) fixVessel(data.vessel);
+            if (Array.isArray(data.positions)) {
+              data.positions = filterPositions(data.positions);
+            }
           }
         } catch (e) { return resp; }
         return new Response(JSON.stringify(data), {

--- a/panel/user/index.html
+++ b/panel/user/index.html
@@ -21,7 +21,7 @@
     </style>
     <!-- Tracking bridge: must run BEFORE the React module so window.fetch
          is patched before any /api/tracking_api.php call fires. -->
-    <script src="./assets/tracking-bridge.js?v=20260510a"></script>
+    <script src="./assets/tracking-bridge.js?v=20260510b"></script>
     <script type="module" crossorigin src="./assets/index-ps6ZIKLW.js"></script>
     <link rel="stylesheet" crossorigin href="./assets/index-DE7qJzrW.css">
   </head>


### PR DESCRIPTION
## Summary

Follow-up to #527. After deploying the first bridge the user reported the map **still** showed an Atlantic-crossing route. Two more bugs found and fixed.

### Bug 1 — `vessel_detail` had no top-level `lat`/`lon`

`featured` returns top-level `lat`/`lon` strings on each vessel. `vessel_detail` does **not** — the AIS coords only live inside the nested `current_position`. `resolveVesselPosition()` reads `v.lat`/`v.lon`, so for `vessel_detail` those came back undefined → NaN → `ais=null` → resolver always fell through to the time-projection fallback. That's why the right detail panel showed MSC Pamela at `-30.6394, -72.1599` instead of its real Panama Canal AIS position `8.45, -79.45` (which is on the corridor).

**Fix:** hoist `current_position.lat`/`current_position.lon` to top-level before the resolver runs.

### Bug 2 — `vessel_positions` track history crossing the Atlantic

The AIS feed returns the ship's **full historical track**. For some vessels that includes Europe coordinates from before/after the booked USA → Chile transit:

```
MSC Pamela        history: Hamburg (53.5,9.9), Antwerp (51.3,4.3),
                          North Sea (52.1,3.2), then Panama, Miami.
CMA CGM Thalassa  history: mostly off Portugal.
```

The /panel/user/ React bundle draws a polyline through every position in the track, producing the visible Atlantic crossing in the screenshot even after our marker fix.

**Fix:** also intercept `action=vessel_positions` and filter the array to a USA-Chile corridor bounding box:

```
lon ∈ [-135, -65]   (West Coast US through East Coast US, with margin)
lat ∈ [ -40,  52]   (south of Valparaíso through north of Seattle)
```

Anything outside the box is dropped. Track points still on the corridor (Miami / Caribbean / Panama / Pacific) are preserved.

## Verified locally

```
vessel_detail MSC Pamela
  before: top-level lat/lon = undefined  -> resolver projected to (-30.6, -72.2)
  after:  top-level lat/lon = 8.45, -79.45 -> kept (on route)

vessel_positions MSC Pamela: 5 sample points (3 Caribbean/Panama, 2 Hamburg)
  after: 3 positions kept, both Hamburg points dropped.
```

## Files
- `panel/user/assets/tracking-bridge.js` — +44/-3 lines
- `panel/user/index.html` — bumped to `?v=20260510b`

## Test plan
- [ ] Deploy + purge Cloudflare + Ctrl+Shift+R.
- [ ] `/panel/user/#seguimiento`: no more Atlantic-crossing line. Polyline (if visible) stays on the Caribbean → Panama → Pacific corridor.
- [ ] Click MSC Pamela: right detail panel shows POSICION ACTUAL = `8.4503, -79.4506` (Panama), **not** `-30.6394, -72.1599`.
- [ ] Click CMA CGM Thalassa: detail panel shows the projected Pacific position (still ~`-30.6, -72.2`), since its real AIS is in Portugal.

https://claude.ai/code/session_01GqCGWuyhatt6tWJcscpwrC

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqCGWuyhatt6tWJcscpwrC)_