### PR TITLE
Tracking bridge: admin parallel + sanitize speed/course=-1 sentinels

### DIFF
--- a/panel/admin/assets/tracking-bridge.js
+++ b/panel/admin/assets/tracking-bridge.js
@@ -1,26 +1,21 @@
 /**
- * Tracking Bridge - /panel/user/ (React bundle)
+ * Tracking Bridge - /panel/admin/ (React bundle)
  *
- * The /panel/user/ Vite + React app fetches /api/tracking_api.php?action=featured
- * and renders ship markers at whatever lat/lon the backend returns. The
- * backend forwards the ship's raw AIS position, which for some vessels is
- * physically OUT of the booked USA -> Chile route (e.g. CMA CGM Thalassa
- * appearing off Portugal). The legacy panel had a tracking-enhancer.js with
- * a route engine; the React panel had nothing.
+ * Admin parallel to /panel/user/assets/tracking-bridge.js. Same route
+ * engine, adapted to the admin endpoints:
  *
- * This script monkey-patches window.fetch BEFORE the React bundle runs.
- * For every tracking_api.php response we:
- *   1. Resolve origin + destination ports from the vessel labels.
- *   2. If the AIS position is within OFF_ROUTE_KM (800 km) of the route
- *      polyline (origin -> Panama Canal -> destination, or direct for
- *      West-coast origins) -> keep the AIS lat/lon.
- *   3. If the AIS position is within ARRIVED_KM (80 km) of the destination
- *      port -> snap to destination + flip status to "arrived".
- *   4. Otherwise -> project a position along the route based on elapsed
- *      time vs ETA, so the marker always sits on the USA -> Chile corridor.
+ *   action=admin_list_vessels   -> response shape {success, vessels|items}
+ *   action=vessel_positions     -> filter to USA-Chile corridor bounding box
  *
- * Ships whose origin/destination we can't resolve are passed through
- * untouched.
+ * Admin CRUD endpoints (admin_create_vessel / admin_update_vessel /
+ * admin_delete_vessel) are NOT intercepted -- those are admin write actions
+ * that must pass through unchanged.
+ *
+ * Behaviour identical to the user bridge: resolve origin + destination
+ * ports, snap to AIS when within 800 km of the corridor, snap to
+ * destination + flip status='arrived' when within 80 km, otherwise project
+ * a position along the route based on elapsed time vs ETA. Speed/course
+ * = -1 (AIS unknown sentinel) is sanitised to null so the UI hides them.
  */
 (function () {
   'use strict';
@@ -222,7 +217,7 @@
       if (url && url.url) url = url.url; else return false;
     }
     if (url.indexOf('tracking_api.php') === -1) return false;
-    return url.indexOf('action=featured') !== -1 ||
+    return url.indexOf('action=admin_list_vessels') !== -1 ||
            url.indexOf('action=vessel_detail') !== -1 ||
            url.indexOf('action=vessel_positions') !== -1;
   }
@@ -244,8 +239,10 @@
       try { cloned = resp.clone(); } catch (e) { return resp; }
       return cloned.json().then(function (data) {
         try {
-          if (data && data.success) {
+          if (data && (data.success || data.vessels || data.items)) {
+            // admin_list_vessels may return either {vessels:[...]} or {items:[...]}
             if (Array.isArray(data.vessels)) data.vessels.forEach(fixVessel);
+            if (Array.isArray(data.items))   data.items.forEach(fixVessel);
             if (data.vessel) fixVessel(data.vessel);
             if (Array.isArray(data.positions)) {
               data.positions = filterPositions(data.positions);

--- a/panel/admin/index.html
+++ b/panel/admin/index.html
@@ -5,6 +5,9 @@
     <link rel="icon" type="image/svg+xml" href="/images/imporlan-favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Imporlan - Panel Admin</title>
+    <!-- Tracking bridge: must run BEFORE the admin React module so
+         window.fetch is patched before any /api/tracking_api.php call. -->
+    <script src="/panel/admin/assets/tracking-bridge.js?v=20260510a"></script>
     <script type="module" crossorigin src="/panel/admin/assets/admin-poSdhtP4.js"></script>
     <link rel="stylesheet" crossorigin href="/panel/admin/assets/admin-RHnCo1OK.css">
   </head>

--- a/panel/user/index.html
+++ b/panel/user/index.html
@@ -21,7 +21,7 @@
     </style>
     <!-- Tracking bridge: must run BEFORE the React module so window.fetch
          is patched before any /api/tracking_api.php call fires. -->
-    <script src="./assets/tracking-bridge.js?v=20260510b"></script>
+    <script src="./assets/tracking-bridge.js?v=20260510c"></script>
     <script type="module" crossorigin src="./assets/index-ps6ZIKLW.js"></script>
     <link rel="stylesheet" crossorigin href="./assets/index-DE7qJzrW.css">
   </head>


### PR DESCRIPTION
## Summary

Two improvements after the user confirmed the user-panel bridge is working in production:

### 1. Admin parallel bridge (`/panel/admin/`)

Pending follow-up from #527/#528. Mirrors the user bridge to the admin React app so admin sees the same USA → Chile-clamped routes and gets the corridor filter for track history.

Admin uses these `tracking_api.php` actions:
- `admin_list_vessels` — list (response `{vessels:[…]}` or `{items:[…]}`)
- `vessel_positions` — same as user
- `vessel_detail` — same as user
- `admin_create_vessel` / `admin_update_vessel` / `admin_delete_vessel` — write actions, **passed through unchanged**

**`panel/admin/assets/tracking-bridge.js` (new)**
- Same route engine (`PORT_COORDS`, `PANAMA_CANAL`, `OFF_ROUTE_KM=800`, `ARRIVED_KM=80`, time-progress fallback).
- `shouldIntercept()` matches `admin_list_vessels` instead of `featured`.
- Response handler accepts both `data.vessels` and `data.items` shapes.

**`panel/admin/index.html`**
- Loads the bridge as blocking `<script>` in `<head>` BEFORE the `type="module"` React bundle so `window.fetch` is patched in time.

### 2. Sanitize `speed=-1` / `course=-1` sentinels

The myshiptracking AIS feed reports `-1.00` for unknown speed/course (e.g. CMA CGM Thalassa). The React UI was printing them verbatim, so the sidebar showed "CMA CGM Thalassa … **-1.00 kn**" — looked broken.

Added `sanitizeTelemetry(v)` to the user bridge (called inside `fixVessel`):
- `speed  < 0` → `null`
- `course < 0` → `null`
- Same on `v.current_position.speed/course`

Admin bridge inherits the same logic via the shared file structure.

## Verified locally

```
USER bridge featured:
  MSC Pamela        speed=19.20  course=161.30  (kept)
  CMA CGM Thalassa  speed=null   course=null    (sanitized)

ADMIN bridge admin_list_vessels:
  MSC Pamela        lat=8.4503,-79.4506   on-route AIS kept
  CMA CGM Thalassa  lat=-30.62,-72.16     projected to Pacific corridor
                    speed=null            sanitized
```

## Files
- `panel/admin/assets/tracking-bridge.js` — new (~210 lines)
- `panel/admin/index.html` — adds bridge `<script>`
- `panel/user/assets/tracking-bridge.js` — `+sanitizeTelemetry`
- `panel/user/index.html` — bumped to `?v=20260510c`

## Test plan
- [ ] Deploy `panel/admin/*` + `panel/user/*`. Purge Cloudflare. Hard refresh.
- [ ] **Admin** `/panel/admin/#seguimiento` (or whatever path admin tracking lives at): markers fall in the USA → Chile corridor, polyline (track history) stays in the Americas/Pacific bounding box.
- [ ] **Admin** create/update/delete a vessel: the form still works (writes are not intercepted).
- [ ] **User** `/panel/user/#seguimiento`: CMA CGM Thalassa sidebar card no longer shows "-1.00 kn"; speed line is hidden or shows nothing.
- [ ] DevTools Network: response of `?action=featured` shows `speed: null` instead of `"-1.00"` for vessels with unknown AIS speed.

https://claude.ai/code/session_01GqCGWuyhatt6tWJcscpwrC

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqCGWuyhatt6tWJcscpwrC)_