### PR TITLE
Tracking: planned-route overlay (USA → Chile dashed lines per vessel)

### DIFF
--- a/panel/admin/assets/tracking-bridge.js
+++ b/panel/admin/assets/tracking-bridge.js
@@ -138,6 +138,20 @@
     return { lat: pt.lat, lon: pt.lon, arrived: false, projected: true };
   }
 
+  // Vessel cache (id -> {origin_label, destination_label}) populated
+  // whenever we see a vessel in admin_list_vessels / vessel_detail. Drives
+  // the planned-route overlay below; survives across map re-renders.
+  var vesselCache = {};
+  function cacheVesselRoute(v) {
+    if (!v || v.id == null) return;
+    if (!v.origin_label || !v.destination_label) return;
+    vesselCache[v.id] = {
+      id: v.id,
+      origin_label: v.origin_label,
+      destination_label: v.destination_label
+    };
+  }
+
   function fixVessel(v) {
     if (!v || typeof v !== 'object') return;
     // vessel_detail responses don't carry top-level lat/lon -- only inside
@@ -152,6 +166,7 @@
     }
     var r = resolveVesselPosition(v);
     if (!r) return; // unknown ports, leave as-is
+    cacheVesselRoute(v);
     v.lat = String(r.lat);
     v.lon = String(r.lon);
     if (r.arrived) v.status = 'arrived';
@@ -257,4 +272,92 @@
       }).catch(function () { return resp; });
     });
   };
+
+  // ============================================
+  // Planned-route overlay (admin)
+  // Same logic as panel/user/assets/tracking-bridge.js: monkey-patch
+  // window.L.map so every newly-created Leaflet instance receives a faint
+  // dashed overlay showing the planned USA -> Chile corridor for every
+  // cached vessel. Origin + destination port dots dedup across vessels
+  // sharing the same route endpoints.
+  // ============================================
+  var ROUTE_COLOR_PLANNED = '#2563eb';
+  var ROUTE_COLOR_ARRIVE  = '#a855f7';
+
+  function addPlannedRoutes(mapInst) {
+    var L = window.L;
+    if (!L || !mapInst) return;
+    var routesDrawn = {};
+    var portsToDraw = {};
+    Object.keys(vesselCache).forEach(function (id) {
+      var v = vesselCache[id];
+      var origin = getPortCoords(v.origin_label);
+      var destination = getPortCoords(v.destination_label);
+      if (!origin || !destination) return;
+      var route = buildRouteWaypoints(origin, destination);
+      if (!route) return;
+      var key = v.origin_label + '|' + v.destination_label;
+      if (!routesDrawn[key]) {
+        routesDrawn[key] = true;
+        var latlngs = route.map(function (p) { return [p.lat, p.lon]; });
+        try {
+          L.polyline(latlngs, {
+            color: ROUTE_COLOR_PLANNED,
+            weight: 2,
+            opacity: 0.4,
+            dashArray: '8 6',
+            smoothFactor: 1,
+            interactive: false
+          }).addTo(mapInst);
+        } catch (e) {}
+      }
+      portsToDraw['o:' + v.origin_label]      = { coords: origin,      isDest: false };
+      portsToDraw['d:' + v.destination_label] = { coords: destination, isDest: true  };
+    });
+    Object.keys(portsToDraw).forEach(function (k) {
+      var p = portsToDraw[k];
+      try {
+        L.circleMarker([p.coords.lat, p.coords.lon], {
+          radius: p.isDest ? 5 : 4,
+          color: '#fff',
+          weight: 1.5,
+          fillColor: p.isDest ? ROUTE_COLOR_ARRIVE : ROUTE_COLOR_PLANNED,
+          fillOpacity: 0.85,
+          interactive: false
+        }).addTo(mapInst);
+      } catch (e) {}
+    });
+  }
+
+  function patchLeafletMap(LeafletNs) {
+    if (!LeafletNs || LeafletNs._impMapPatched) return;
+    LeafletNs._impMapPatched = true;
+    var origMap = LeafletNs.map;
+    LeafletNs.map = function () {
+      var inst = origMap.apply(this, arguments);
+      setTimeout(function () {
+        try { addPlannedRoutes(inst); } catch (e) {}
+      }, 100);
+      return inst;
+    };
+  }
+
+  if (window.L) {
+    patchLeafletMap(window.L);
+  } else {
+    try {
+      var realL;
+      Object.defineProperty(window, 'L', {
+        configurable: true,
+        enumerable: true,
+        get: function () { return realL; },
+        set: function (val) { realL = val; patchLeafletMap(val); }
+      });
+    } catch (e) {
+      var iv = setInterval(function () {
+        if (window.L) { clearInterval(iv); patchLeafletMap(window.L); }
+      }, 25);
+      setTimeout(function () { clearInterval(iv); }, 30000);
+    }
+  }
 })();

--- a/panel/admin/index.html
+++ b/panel/admin/index.html
@@ -7,7 +7,7 @@
     <title>Imporlan - Panel Admin</title>
     <!-- Tracking bridge: must run BEFORE the admin React module so
          window.fetch is patched before any /api/tracking_api.php call. -->
-    <script src="/panel/admin/assets/tracking-bridge.js?v=20260510a"></script>
+    <script src="/panel/admin/assets/tracking-bridge.js?v=20260510b"></script>
     <script type="module" crossorigin src="/panel/admin/assets/admin-poSdhtP4.js"></script>
     <link rel="stylesheet" crossorigin href="/panel/admin/assets/admin-RHnCo1OK.css">
   </head>

--- a/panel/user/assets/tracking-bridge.js
+++ b/panel/user/assets/tracking-bridge.js
@@ -143,6 +143,20 @@
     return { lat: pt.lat, lon: pt.lon, arrived: false, projected: true };
   }
 
+  // Vessel cache (id -> {origin_label, destination_label}) populated whenever
+  // we see a vessel in featured / vessel_detail. Drives the planned-route
+  // overlay below; survives across map re-renders.
+  var vesselCache = {};
+  function cacheVesselRoute(v) {
+    if (!v || v.id == null) return;
+    if (!v.origin_label || !v.destination_label) return;
+    vesselCache[v.id] = {
+      id: v.id,
+      origin_label: v.origin_label,
+      destination_label: v.destination_label
+    };
+  }
+
   function fixVessel(v) {
     if (!v || typeof v !== 'object') return;
     // vessel_detail responses don't carry top-level lat/lon -- only inside
@@ -157,6 +171,7 @@
     }
     var r = resolveVesselPosition(v);
     if (!r) return; // unknown ports, leave as-is
+    cacheVesselRoute(v);
     v.lat = String(r.lat);
     v.lon = String(r.lon);
     if (r.arrived) v.status = 'arrived';
@@ -260,4 +275,105 @@
       }).catch(function () { return resp; });
     });
   };
+
+  // ============================================
+  // Planned-route overlay
+  // ----------------------------------------------
+  // The React bundle only draws the SELECTED vessel's track history. We
+  // additionally drop a faint dashed overlay onto the map for EVERY cached
+  // vessel showing its planned USA -> Chile corridor (origin port -> Panama
+  // Canal -> destination port for East/Gulf coast US origins, or origin ->
+  // destination for West Coast US origins). This is what the user originally
+  // asked for: that the map always communicates "these ships are coming to
+  // Chile".
+  //
+  // We monkey-patch window.L.map: every time the React effect creates a new
+  // map instance, we drop our overlay 100 ms later (after the bundle has
+  // finished its synchronous setup). On subsequent re-renders the bundle
+  // calls map.remove() and creates a new instance; our patch fires again on
+  // that new instance, so the overlay is always present.
+  // ============================================
+  var ROUTE_COLOR_PLANNED = '#2563eb';
+  var ROUTE_COLOR_ARRIVE  = '#a855f7';
+
+  function addPlannedRoutes(mapInst) {
+    var L = window.L;
+    if (!L || !mapInst) return;
+    var routesDrawn = {};
+    var portsToDraw = {};
+    Object.keys(vesselCache).forEach(function (id) {
+      var v = vesselCache[id];
+      var origin = getPortCoords(v.origin_label);
+      var destination = getPortCoords(v.destination_label);
+      if (!origin || !destination) return;
+      var route = buildRouteWaypoints(origin, destination);
+      if (!route) return;
+      var key = v.origin_label + '|' + v.destination_label;
+      if (!routesDrawn[key]) {
+        routesDrawn[key] = true;
+        var latlngs = route.map(function (p) { return [p.lat, p.lon]; });
+        try {
+          L.polyline(latlngs, {
+            color: ROUTE_COLOR_PLANNED,
+            weight: 2,
+            opacity: 0.4,
+            dashArray: '8 6',
+            smoothFactor: 1,
+            interactive: false
+          }).addTo(mapInst);
+        } catch (e) {}
+      }
+      portsToDraw['o:' + v.origin_label]      = { coords: origin,      isDest: false };
+      portsToDraw['d:' + v.destination_label] = { coords: destination, isDest: true  };
+    });
+    Object.keys(portsToDraw).forEach(function (k) {
+      var p = portsToDraw[k];
+      try {
+        L.circleMarker([p.coords.lat, p.coords.lon], {
+          radius: p.isDest ? 5 : 4,
+          color: '#fff',
+          weight: 1.5,
+          fillColor: p.isDest ? ROUTE_COLOR_ARRIVE : ROUTE_COLOR_PLANNED,
+          fillOpacity: 0.85,
+          interactive: false
+        }).addTo(mapInst);
+      } catch (e) {}
+    });
+  }
+
+  function patchLeafletMap(LeafletNs) {
+    if (!LeafletNs || LeafletNs._impMapPatched) return;
+    LeafletNs._impMapPatched = true;
+    var origMap = LeafletNs.map;
+    LeafletNs.map = function () {
+      var inst = origMap.apply(this, arguments);
+      setTimeout(function () {
+        try { addPlannedRoutes(inst); } catch (e) {}
+      }, 100);
+      return inst;
+    };
+  }
+
+  // If Leaflet is already loaded (rare race), patch immediately. Otherwise
+  // intercept the moment the bundle assigns window.L. Defining a setter via
+  // Object.defineProperty is bulletproof: Leaflet's IIFE ends with
+  // `window.L = L` which fires our setter before any other code touches it.
+  if (window.L) {
+    patchLeafletMap(window.L);
+  } else {
+    try {
+      var realL;
+      Object.defineProperty(window, 'L', {
+        configurable: true,
+        enumerable: true,
+        get: function () { return realL; },
+        set: function (val) { realL = val; patchLeafletMap(val); }
+      });
+    } catch (e) {
+      var iv = setInterval(function () {
+        if (window.L) { clearInterval(iv); patchLeafletMap(window.L); }
+      }, 25);
+      setTimeout(function () { clearInterval(iv); }, 30000);
+    }
+  }
 })();

--- a/panel/user/index.html
+++ b/panel/user/index.html
@@ -21,7 +21,7 @@
     </style>
     <!-- Tracking bridge: must run BEFORE the React module so window.fetch
          is patched before any /api/tracking_api.php call fires. -->
-    <script src="./assets/tracking-bridge.js?v=20260510c"></script>
+    <script src="./assets/tracking-bridge.js?v=20260510d"></script>
     <script type="module" crossorigin src="./assets/index-ps6ZIKLW.js"></script>
     <link rel="stylesheet" crossorigin href="./assets/index-DE7qJzrW.css">
   </head>


### PR DESCRIPTION
## Summary

The React bundles only draw the **selected** vessel's track history. The other 3 ships in the list show only their current marker. The user asked for *"siempre se vean rutas entre USA y los puertos de Chile"* — so we add a **faint dashed overlay onto the map for every cached vessel** showing its planned corridor (origin port → Panama Canal → destination port). Always visible, regardless of selection.

## How it works

1. **`vesselCache`** (id → `{origin_label, destination_label}`) is populated inside `fixVessel()`, so it fills the first time a `featured` / `admin_list_vessels` / `vessel_detail` response is intercepted.

2. **`addPlannedRoutes(mapInst)`** iterates every cached vessel:
   - Builds waypoints via `getPortCoords()` + `buildRouteWaypoints()`
   - **De-dupes** by route signature (`origin|destination`) so two vessels sharing Miami → San Antonio draw the polyline once
   - Renders each polyline dashed (`#2563eb`, weight 2, opacity 0.4, `dashArray "8 6"`), `interactive: false`
   - Adds origin (blue) and destination (purple, slightly larger) port dots, deduped, also `interactive: false`. Purple matches the existing "Arribado" legend.

3. **`patchLeafletMap(L)`** wraps `L.map` so every newly-created Leaflet instance gets `addPlannedRoutes()` after a 100 ms delay (lets the React effect finish its synchronous `setView` + tile layer + marker setup before our overlay drops in).

4. **Bootstrap**: if `window.L` is already there, patch immediately. Otherwise install a one-shot `Object.defineProperty` setter on `window.L` that fires the moment Leaflet's IIFE assigns it, so we patch BEFORE the bundle's own `if (window.L)` poll resolves. Falls back to a 25 ms polling interval if `defineProperty` throws.

## Multi-render handling

The React effect re-runs when `vessels` or `selectedId` change. Each re-run does `a.current.remove()` then `L.map(...)` again. Our patch is permanent (installed once on the `L` namespace), so the new instance gets a fresh overlay — the old one is GC'd with the removed map.

## Verified locally

Mock-map smoke test against the live 4-vessel API:

```
Layers added: 10
  polylines (planned routes): 4 (one per unique origin)
  circles (port dots):        6 (4 US origins + 2 Chile destinations, deduped)

route 0: Miami           (25.8,-80.2) -> Panama -> San Antonio
route 1: Houston         (29.7,-95.0) -> Panama -> Valparaíso
route 2: Fort Lauderdale (26.1,-80.1) -> Panama -> San Antonio
route 3: Jacksonville    (30.3,-81.7) -> Panama -> Valparaíso
```

## Files
- `panel/user/assets/tracking-bridge.js` — `+vesselCache, +addPlannedRoutes, +patchLeafletMap, +bootstrap`
- `panel/admin/assets/tracking-bridge.js` — same additions (admin parallel)
- `panel/user/index.html` — bumped to `?v=20260510d`
- `panel/admin/index.html` — bumped to `?v=20260510b`

## Test plan
- [ ] Deploy 4 files. Purge Cloudflare. Hard refresh.
- [ ] `/panel/user/#seguimiento`: 4 dashed blue routes visible, each going from a US port → Panama → San Antonio or Valparaíso. Origin dots blue, destination dots purple. Routes visible regardless of which vessel is selected.
- [ ] Click on different vessels: dashed routes stay visible; only the active **track** (solid line) changes.
- [ ] `/panel/admin/`: same behavior on the admin tracking map.
- [ ] DevTools Network: Leaflet still loaded normally; no console errors about defineProperty or L.map.

https://claude.ai/code/session_01GqCGWuyhatt6tWJcscpwrC

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqCGWuyhatt6tWJcscpwrC)_