### PR TITLE
Deploy safety: harden auto-deploy + reusable guard + cPanel restructure doc

### DIFF
--- a/DEPLOY-SAFETY.md
+++ b/DEPLOY-SAFETY.md
@@ -1,0 +1,161 @@
+# Deploy Safety — Imporlan + Tourevo Shared Hosting
+
+## The problem we keep hitting
+
+`imporlan.cl` and `tourevo.cl` live on the **same cPanel account**
+(`wwimpo@single-4020.banahosting.com`). Imporlan is configured as the
+**primary domain** of that account, so its doc-root is the bare
+`~/public_html/`. Tourevo is an addon/alias on the same account.
+
+The two domains end up sharing the same physical directory tree on the
+server. Apache picks which content to serve via Host-aware rewrite rules
+in `.htaccess`, but at the filesystem level **both sites can write to
+the same path**.
+
+Concretely: a `cp -Rf` from a Tourevo build into `~/public_html/` will
+overwrite Imporlan's `index.html`, and vice versa. We've seen this in
+production multiple times (incidents on 2026-04-19 and 2026-05-11).
+
+## Short-term mitigations (this repo)
+
+### 1. Sentinel file + identity check
+
+After every successful deploy, `auto-deploy.sh` and `deploy-prod.sh`
+write a sentinel marker:
+
+```
+~/public_html/.imporlan_docroot
+```
+
+Before the next deploy, both scripts check that:
+
+- the sentinel exists, **OR**
+- the existing `index.html` contains an Imporlan-identifying string
+  (`imporlan` or `Importación de Lanchas`).
+
+If neither is true the deploy aborts with exit code 2 and takes a
+**defensive snapshot** of whatever was at `~/public_html/` into
+`~/backups/unknown_docroot_<timestamp>` so we can recover it if it
+turns out to be another site's content.
+
+### 2. Post-deploy verification + auto-rollback
+
+After deploying, `auto-deploy.sh` curls `https://www.imporlan.cl/` and
+requires the response to contain an Imporlan marker. If it doesn't:
+
+- the script logs an `ALERT:` line into `~/auto-deploy.log`,
+- restores the previous `index.html` from the pre-deploy snapshot,
+- exits with code 3.
+
+Cron should be configured to email/notify on non-zero exits.
+
+### 3. Reusable guard for Tourevo (or any other site)
+
+`deploy-guard.sh` is a stand-alone script in this repo intended to be
+**copied into the Tourevo repo** (or any other repo that deploys into
+this cPanel account). It performs the same sentinel+marker check but
+parameterised, so each site protects its own doc-root.
+
+Example call from a hypothetical Tourevo `deploy-prod.sh`:
+
+```bash
+# Refuse to overwrite a non-Tourevo doc-root
+bash deploy-guard.sh \
+  --target /home/wwimpo/tourevo \
+  --site tourevo \
+  --marker 'Tourevo|Tours Privados' \
+  --backup-dir /home/wwimpo/backups
+GUARD_EXIT=$?
+[ "$GUARD_EXIT" -ne 0 ] && exit "$GUARD_EXIT"
+```
+
+And after a successful deploy Tourevo should write its own sentinel:
+
+```bash
+echo "Tourevo doc-root, last deploy: $(date)" > /home/wwimpo/tourevo/.tourevo_docroot
+```
+
+## Long-term permanent fix (cPanel restructure)
+
+The short-term mitigations make accidental overwrites loud instead of
+silent, but the structural problem is the **shared doc-root**. The
+proper fix is to give each domain its own physical directory:
+
+```
+/home/wwimpo/imporlan.cl/        <- new Imporlan doc-root
+/home/wwimpo/tourevo.cl/         <- new Tourevo doc-root
+/home/wwimpo/public_html/        <- only a parking page (or empty)
+```
+
+### Steps (perform once, requires hosting admin access)
+
+1. **In cPanel: change Imporlan's primary doc-root.**
+
+   On banahosting cPanel this is typically under *Domains → Manage →
+   Document Root*. Some shared-hosting providers do not allow changing
+   the primary domain's doc-root through the panel; if that's the
+   case, open a ticket with banahosting support requesting:
+
+   > Please change the document root of the primary domain
+   > `imporlan.cl` from `public_html` to `imporlan.cl` (a sibling
+   > directory of `public_html`).
+
+2. **Stop the auto-deploy cron** temporarily so it doesn't fight us.
+
+3. **Move the current contents:**
+
+   ```bash
+   mkdir -p ~/imporlan.cl
+   # Move everything except .htaccess-protected dotfiles and tourevo bits
+   rsync -av --exclude='.htaccess' --exclude='.tourevo*' \
+         ~/public_html/ ~/imporlan.cl/
+   # Copy the .htaccess separately so we can review it
+   cp ~/public_html/.htaccess ~/imporlan.cl/.htaccess
+   ```
+
+4. **Confirm Tourevo content is isolated.** If Tourevo was already
+   addon'd to a separate folder (likely `~/tourevo.cl/` or
+   `~/public_html/tourevo/`), nothing more to do. If Tourevo content
+   is currently scattered in `~/public_html/` (e.g. `assets/tours/`,
+   `assets/fleet/`, `photo-service/`, `/tourevo/`), move it to
+   `~/tourevo.cl/` and make sure Tourevo's vhost points there.
+
+5. **Update `auto-deploy.sh`** so `PUBLIC_HTML="/home/wwimpo/imporlan.cl"`.
+
+6. **Re-enable the cron**, run a deploy, verify https://imporlan.cl
+   still serves Imporlan content.
+
+7. **Communicate the change** to whoever maintains Tourevo's deploy
+   pipeline so they update their own `PUBLIC_HTML` constant.
+
+After the restructure, the two sites cannot overwrite each other even
+in the worst case (faulty deploy script, FTP into the wrong folder,
+manual `rm -rf` typo). The deploy-guard.sh + sentinel system stays
+in place as defence in depth.
+
+## Quick reference: incident response
+
+If imporlan.cl serves the wrong content again:
+
+```bash
+# 1. Confirm the swap is at the filesystem level (not Cloudflare cache):
+curl -fsSI https://www.imporlan.cl/.imporlan_docroot   # expect 200
+curl -fsSL https://www.imporlan.cl/ | grep -oE '<title>[^<]+</title>'
+
+# 2. Restore the home page from the latest main:
+TMP=~/imporlan-restore-$(date +%s)
+git clone --depth=1 https://github.com/jpchs1/Imporlan.git "$TMP"
+cp ~/public_html/index.html ~/public_html/index.html.foreign-backup-$(date +%s)
+cp -a "$TMP/index.html" ~/public_html/index.html
+rm -rf "$TMP"
+
+# 3. Refresh the sentinel so the next auto-deploy won't trip the guard:
+cat > ~/public_html/.imporlan_docroot <<EOF
+Imporlan doc-root, restored manually $(date)
+EOF
+chmod 644 ~/public_html/.imporlan_docroot
+
+# 4. Cloudflare -> Purge Everything.
+# 5. Investigate auto-deploy.log + look at the .foreign-backup-* file to
+#    identify which site's deploy ran into our doc-root.
+```

--- a/auto-deploy.sh
+++ b/auto-deploy.sh
@@ -4,6 +4,12 @@ set -euo pipefail
 # ============================================
 #  IMPORLAN - Auto Deploy from GitHub
 #  Runs via cron, pulls latest and deploys
+#
+#  Safety: this script REFUSES to deploy on top of $PUBLIC_HTML unless it
+#  can confirm the target is an Imporlan doc-root (sentinel + index.html
+#  marker fallback). The doc-root is shared with tourevo.cl on this hosting
+#  account, so a blind cp -Rf could wipe out Tourevo content if the
+#  identity check is skipped. See DEPLOY-SAFETY.md.
 # ============================================
 
 REPO_DIR="/home/wwimpo/imporlan-staging"
@@ -11,11 +17,14 @@ PUBLIC_HTML="/home/wwimpo/public_html"
 BACKUP_DIR="/home/wwimpo/backups"
 LOGFILE="/home/wwimpo/auto-deploy.log"
 LOCKFILE="/home/wwimpo/.deploy.lock"
+SENTINEL="$PUBLIC_HTML/.imporlan_docroot"
 TIMESTAMP=$(date +%Y-%m-%d_%H%M%S)
+
+log() { echo "[$TIMESTAMP] $*" >> "$LOGFILE"; }
 
 # Prevent concurrent runs
 if [ -f "$LOCKFILE" ]; then
-  echo "[$TIMESTAMP] Deploy already running, skipping." >> "$LOGFILE"
+  log "Deploy already running, skipping."
   exit 0
 fi
 trap 'rm -f "$LOCKFILE"' EXIT
@@ -23,7 +32,7 @@ touch "$LOCKFILE"
 
 # Clone repo if it doesn't exist yet
 if [ ! -d "$REPO_DIR/.git" ]; then
-  echo "[$TIMESTAMP] Cloning repository..." >> "$LOGFILE"
+  log "Cloning repository..."
   git clone https://github.com/jpchs1/Imporlan.git "$REPO_DIR" >> "$LOGFILE" 2>&1
 fi
 
@@ -36,13 +45,35 @@ LOCAL=$(git rev-parse HEAD)
 REMOTE=$(git rev-parse origin/main)
 
 if [ "$LOCAL" = "$REMOTE" ]; then
-  # No changes, nothing to deploy
   exit 0
 fi
 
-echo "[$TIMESTAMP] New changes detected. Deploying..." >> "$LOGFILE"
-echo "  Local:  $LOCAL" >> "$LOGFILE"
-echo "  Remote: $REMOTE" >> "$LOGFILE"
+log "New changes detected. Deploying..."
+log "  Local:  $LOCAL"
+log "  Remote: $REMOTE"
+
+# ---------------------------------------------------------------------------
+# IDENTITY CHECK: confirm $PUBLIC_HTML is an Imporlan doc-root before writing.
+# Refuses to deploy if it looks like another site's content is currently
+# living there. See deploy-prod.sh for the manual override (FORCE=1).
+# ---------------------------------------------------------------------------
+IDENTITY_OK=0
+if [ -f "$SENTINEL" ]; then
+  IDENTITY_OK=1
+elif [ -f "$PUBLIC_HTML/index.html" ] && \
+     grep -qiE 'imporlan|Importaci[oó]n de Lanchas' "$PUBLIC_HTML/index.html"; then
+  IDENTITY_OK=1
+fi
+if [ "$IDENTITY_OK" -eq 0 ]; then
+  log "ABORT: $PUBLIC_HTML does not look like an Imporlan doc-root."
+  log "       No sentinel ($SENTINEL) and index.html has no Imporlan markers."
+  log "       Refusing to overwrite — would clobber another site."
+  mkdir -p "$BACKUP_DIR"
+  UNKNOWN_SNAPSHOT="$BACKUP_DIR/unknown_docroot_${TIMESTAMP}"
+  cp -a "$PUBLIC_HTML" "$UNKNOWN_SNAPSHOT" 2>/dev/null && \
+    log "       Defensive snapshot saved at $UNKNOWN_SNAPSHOT."
+  exit 2
+fi
 
 git checkout main >> "$LOGFILE" 2>&1
 git pull origin main >> "$LOGFILE" 2>&1
@@ -51,6 +82,9 @@ git pull origin main >> "$LOGFILE" 2>&1
 mkdir -p "$BACKUP_DIR/pre_deploy_$TIMESTAMP"
 [ -f "$PUBLIC_HTML/api/db_config.php" ] && cp "$PUBLIC_HTML/api/db_config.php" "$BACKUP_DIR/pre_deploy_$TIMESTAMP/db_config.php"
 [ -d "$PUBLIC_HTML/api/marketplace_photos" ] && cp -a "$PUBLIC_HTML/api/marketplace_photos" "$BACKUP_DIR/pre_deploy_$TIMESTAMP/marketplace_photos"
+
+# --- Pre-deploy: snapshot current index.html for emergency rollback ---
+[ -f "$PUBLIC_HTML/index.html" ] && cp "$PUBLIC_HTML/index.html" "$BACKUP_DIR/pre_deploy_$TIMESTAMP/index.html.before"
 
 # --- Deploy root files ---
 for f in index.html marketplace.html robots.txt sitemap.xml favicon.ico .htaccess; do
@@ -85,11 +119,38 @@ done
 [ -f "$BACKUP_DIR/pre_deploy_$TIMESTAMP/db_config.php" ] && cp "$BACKUP_DIR/pre_deploy_$TIMESTAMP/db_config.php" "$PUBLIC_HTML/api/db_config.php"
 [ -d "$BACKUP_DIR/pre_deploy_$TIMESTAMP/marketplace_photos" ] && cp -a "$BACKUP_DIR/pre_deploy_$TIMESTAMP/marketplace_photos" "$PUBLIC_HTML/api/marketplace_photos"
 
+# --- Refresh sentinel (timestamp + commit) ---
+cat > "$SENTINEL" <<SENTINEL_EOF
+This directory is the Imporlan production doc-root.
+Last deploy: $TIMESTAMP
+Commit:      $(git rev-parse HEAD)
+Do not delete this file -- deploy scripts check for it before writing.
+SENTINEL_EOF
+chmod 644 "$SENTINEL"
+
 # --- Set permissions ---
 find "$PUBLIC_HTML" -type d -exec chmod 755 {} +
 find "$PUBLIC_HTML" -type f -exec chmod 644 {} +
 
+# --- Post-deploy verification (catches overwrites by other deploys) ---
+# Probe https://www.imporlan.cl/ and require the response to contain an
+# Imporlan-identifying string. If not, restore the previous index.html
+# and exit with error -- so the cron logs scream instead of leaving the
+# site silently broken.
+sleep 2
+LIVE_BODY=$(curl -fsSL --max-time 15 -H 'Cache-Control: no-cache' "https://www.imporlan.cl/?cb=$TIMESTAMP" 2>/dev/null || true)
+if echo "$LIVE_BODY" | grep -qiE 'imporlan|Importaci[oó]n de Lanchas'; then
+  log "Verification OK: imporlan.cl serves Imporlan content."
+else
+  log "ALERT: imporlan.cl did NOT return Imporlan content after deploy."
+  if [ -f "$BACKUP_DIR/pre_deploy_$TIMESTAMP/index.html.before" ]; then
+    cp "$BACKUP_DIR/pre_deploy_$TIMESTAMP/index.html.before" "$PUBLIC_HTML/index.html"
+    log "       Restored previous index.html from snapshot."
+  fi
+  exit 3
+fi
+
 # --- Cleanup old backups (keep last 10) ---
 cd "$BACKUP_DIR" && ls -dt pre_deploy_* 2>/dev/null | tail -n +11 | xargs rm -rf 2>/dev/null || true
 
-echo "[$TIMESTAMP] Deploy complete. Now at $(git rev-parse --short HEAD)" >> "$LOGFILE"
+log "Deploy complete. Now at $(git rev-parse --short HEAD)"

--- a/deploy-guard.sh
+++ b/deploy-guard.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# ============================================
+#  deploy-guard.sh
+# ============================================
+#  Sentinel-aware doc-root identity guard.
+#
+#  PURPOSE
+#  -------
+#  imporlan.cl and tourevo.cl share the same cPanel account
+#  (/home/wwimpo/public_html). Any naive `cp -Rf` from a Tourevo build
+#  into $PUBLIC_HTML will obliterate Imporlan content (this has happened).
+#  Conversely a Tourevo-deployed `index.html` will replace Imporlan's.
+#
+#  This script must be sourced (or called) by every deploy script before
+#  it writes a single byte into the target directory. It checks:
+#
+#    1. A `.<site>_docroot` sentinel file is present, OR
+#    2. The existing `index.html` contains a site-identifying marker.
+#
+#  If neither is true the script refuses and exits non-zero so the deploy
+#  aborts. The caller can override with FORCE=1.
+#
+#  USAGE (from any deploy script)
+#  ------------------------------
+#  Call directly:
+#    bash /path/to/deploy-guard.sh \
+#         --target /home/wwimpo/public_html \
+#         --site imporlan \
+#         --marker 'imporlan|Importaci[oó]n de Lanchas' \
+#         --backup-dir /home/wwimpo/backups
+#
+#  Or source it for use as a function:
+#    source /path/to/deploy-guard.sh
+#    deploy_guard \
+#      --target /home/wwimpo/tourevo \
+#      --site tourevo \
+#      --marker 'Tourevo|Tours Privados' \
+#      --backup-dir /home/wwimpo/backups
+#
+#  EXIT CODES
+#  ----------
+#    0   -> doc-root identity matches, safe to deploy.
+#    2   -> doc-root looks unrelated (different site or empty). Aborted.
+#    3   -> target directory missing.
+# ============================================
+
+deploy_guard() {
+  local TARGET="" SITE="" MARKER="" BACKUP_DIR=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --target)     TARGET="$2";     shift 2 ;;
+      --site)       SITE="$2";       shift 2 ;;
+      --marker)     MARKER="$2";     shift 2 ;;
+      --backup-dir) BACKUP_DIR="$2"; shift 2 ;;
+      *)            echo "deploy_guard: unknown arg $1" >&2; return 64 ;;
+    esac
+  done
+
+  if [ -z "$TARGET" ] || [ -z "$SITE" ] || [ -z "$MARKER" ]; then
+    echo "deploy_guard: --target, --site and --marker are required" >&2
+    return 64
+  fi
+
+  if [ ! -d "$TARGET" ]; then
+    echo "deploy_guard: target $TARGET does not exist" >&2
+    return 3
+  fi
+
+  local SENTINEL="$TARGET/.${SITE}_docroot"
+  local OK=0
+  [ -f "$SENTINEL" ] && OK=1
+  if [ "$OK" -eq 0 ] && [ -f "$TARGET/index.html" ]; then
+    grep -qiE "$MARKER" "$TARGET/index.html" && OK=1
+  fi
+
+  if [ "$OK" -eq 1 ]; then
+    return 0
+  fi
+
+  echo ""
+  echo "================================================"
+  echo "  deploy_guard REFUSED to deploy $SITE on top of"
+  echo "  $TARGET"
+  echo "  - sentinel $SENTINEL: $([ -f "$SENTINEL" ] && echo present || echo MISSING)"
+  echo "  - index.html marker:  MISSING"
+  echo "  This usually means another site is currently living"
+  echo "  in this directory. Set FORCE=1 to override."
+  echo "================================================"
+
+  if [ "${FORCE:-0}" = "1" ]; then
+    echo "  FORCE=1 set, continuing anyway."
+    return 0
+  fi
+
+  if [ -n "$BACKUP_DIR" ]; then
+    mkdir -p "$BACKUP_DIR"
+    local SNAP="$BACKUP_DIR/unknown_docroot_$(date +%Y-%m-%d_%H%M%S)"
+    cp -a "$TARGET" "$SNAP" 2>/dev/null && \
+      echo "  Defensive snapshot of current $TARGET saved at: $SNAP"
+  fi
+  return 2
+}
+
+# When called directly (not sourced), parse args and exit with the
+# guard's return code.
+if [ "${BASH_SOURCE[0]:-$0}" = "${0}" ]; then
+  deploy_guard "$@"
+  exit $?
+fi


### PR DESCRIPTION
## Diagnóstico

`imporlan.cl` y `tourevo.cl` viven en la **misma cuenta cPanel** y comparten la misma docroot física. Confirmado en producción:

```
tourevo.cl/.imporlan_docroot     -> 200 OK ← MISMA FILE
imporlan.cl/.imporlan_docroot    -> 200 OK
imporlan.cl/assets/tours/real/   -> 200 (asset de Tourevo!)
imporlan.cl/fleet/               -> 200 (carpeta de Tourevo)
imporlan.cl/photo-service/       -> 200 (carpeta de Tourevo)
```

Imporlan es el dominio primario del cPanel → su docroot es `~/public_html/`. Tourevo (addon o alias) escribe en el mismo directorio físico. Apache rutea por `Host:`, pero a nivel filesystem ambos sitios pueden pisarse mutuamente. Eso pasó hoy y pasa "todo el tiempo".

## Lo que entrego en este PR (sin tocar production code)

### `auto-deploy.sh` endurecido
- **Sentinel check** (igual que ya tenía `deploy-prod.sh`): si `.imporlan_docroot` no existe AND `index.html` no contiene marker de Imporlan → aborta con exit 2 y snapshot defensivo de lo que había.
- **Escribe el sentinel** tras cada deploy exitoso.
- **Post-deploy verification**: hace `curl https://www.imporlan.cl/` y verifica que la respuesta contenga marker de Imporlan. Si no → restaura el `index.html` previo del snapshot y sale con exit 3 (el cron log avisa).

### `deploy-guard.sh` (nuevo) — guard reutilizable
- Stand-alone, parametrizable. **Pensado para copiarse al repo de Tourevo** (o cualquier otro sitio del mismo cPanel) y que cada sitio proteja su propia docroot antes de escribir.
- Flags: `--target / --site / --marker / --backup-dir`.
- Exit codes: `0=ok`, `2=refused`, `3=missing target`.
- `FORCE=1` para override.
- Smoke-tested con 4 escenarios (rechazo, sentinel pass, marker pass, force override).

### `DEPLOY-SAFETY.md` (nuevo) — documentación
- Causa raíz explicada
- Mitigaciones cortas
- **Fix permanente cPanel**: pasos para pedirle a banahosting (o configurar via cPanel) que cada dominio tenga su propio docroot físico (`~/imporlan.cl/` + `~/tourevo.cl/`), dejando `~/public_html/` como parking.
- Playbook de incidente: comandos exactos que usé hoy para restaurar.

## Test plan
- [ ] Deploy normal (con sentinel presente): `auto-deploy.sh` corre, hace pull, deploy, refresca sentinel, verifica live, exit 0. Sin cambios visibles en producción.
- [ ] Simular pisado: borrar `~/public_html/.imporlan_docroot` y poner un `index.html` foráneo → siguiente `auto-deploy.sh` debe abortar con exit 2 y guardar `~/backups/unknown_docroot_<ts>/`.
- [ ] Simular post-deploy roto: borrar el contenido del live después del deploy → la verification falla, restaura `index.html.before`, exit 3, log "ALERT:".
- [ ] `deploy-guard.sh` puede sourcearse en el deploy de Tourevo.

## Próximo paso recomendado (afuera de este PR)
Hacer el restructure cPanel descrito en `DEPLOY-SAFETY.md`: docroots separados por dominio. Eso elimina el problema **a nivel filesystem** (no a nivel script).

https://claude.ai/code/session_01GqCGWuyhatt6tWJcscpwrC

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqCGWuyhatt6tWJcscpwrC)_