### PR TITLE
Fix MercadoPago purchases stuck as 'pending' after MP confirms 'approved'

### DIFF
--- a/api/fix_mercadopago_purchases.php
+++ b/api/fix_mercadopago_purchases.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * Fix existing MercadoPago purchases that are stuck in `status: pending`
+ * even though the payment was approved by MercadoPago.
+ *
+ * BACKGROUND
+ * ----------
+ * api/mercadopago.php's handleWebhook() saves a purchase row ONLY when
+ * MercadoPago has already confirmed payment.status === 'approved' (the
+ * webhook handler does a server-side call to api.mercadopago.com to
+ * verify, and only enters the save branch on 'approved'). Despite that,
+ * the savePurchase() call hardcoded the local status to 'pending'.
+ * Therefore every MP-paid row in purchases.json with status='pending'
+ * IS actually paid -- the money is in MercadoPago, only the local label
+ * is wrong.
+ *
+ * This script flips status='pending' -> 'paid' for every row where
+ * payment_method === 'mercadopago' AND payment_id is non-empty.
+ *
+ * SAFETY
+ * - Takes a timestamped backup of purchases.json before writing.
+ * - Refuses to run if backup write fails.
+ * - Idempotent: running twice is harmless (rows already 'paid' are skipped).
+ * - Browser invocation gated by a key (same pattern as fix_webpay_purchases.php).
+ *
+ * USAGE
+ *   php fix_mercadopago_purchases.php                          (CLI, dry-run)
+ *   php fix_mercadopago_purchases.php --apply                  (CLI, apply)
+ *   https://www.imporlan.cl/api/fix_mercadopago_purchases.php?key=MIGRATION_KEY_2026
+ *     -> default browser invocation = APPLY
+ *   Append &dry=1 to do a browser dry-run.
+ */
+
+header('Content-Type: application/json');
+
+$IS_CLI = (php_sapi_name() === 'cli');
+$EXPECTED_KEY = 'MIGRATION_KEY_2026';
+$runKey = $_GET['key'] ?? '';
+
+if (!$IS_CLI && $runKey !== $EXPECTED_KEY) {
+    http_response_code(401);
+    echo json_encode(['error' => 'Unauthorized. Provide ?key=<MIGRATION_KEY>']);
+    exit;
+}
+
+// Determine dry-run vs apply
+$DRY_RUN = false;
+if ($IS_CLI) {
+    $DRY_RUN = !in_array('--apply', $argv);
+} else {
+    $DRY_RUN = isset($_GET['dry']) && $_GET['dry'] === '1';
+}
+
+$purchasesFile = __DIR__ . '/purchases.json';
+
+if (!file_exists($purchasesFile)) {
+    echo json_encode(['error' => 'purchases.json not found at ' . $purchasesFile]);
+    exit;
+}
+
+$raw = file_get_contents($purchasesFile);
+$data = json_decode($raw, true);
+
+if (!is_array($data) || !isset($data['purchases']) || !is_array($data['purchases'])) {
+    echo json_encode(['error' => 'purchases.json is not in the expected {"purchases":[...]} shape']);
+    exit;
+}
+
+$report = [
+    'dry_run' => $DRY_RUN,
+    'backup_file' => null,
+    'total_rows' => count($data['purchases']),
+    'mp_rows' => 0,
+    'mp_pending' => 0,
+    'mp_already_paid' => 0,
+    'mp_missing_payment_id' => 0,
+    'migrated_ids' => [],
+    'skipped' => []
+];
+
+$nowIso = date('Y-m-d H:i:s');
+
+foreach ($data['purchases'] as $i => $p) {
+    $method = strtolower($p['payment_method'] ?? '');
+    if ($method !== 'mercadopago') continue;
+    $report['mp_rows']++;
+
+    $status = strtolower($p['status'] ?? '');
+    if ($status === 'paid') {
+        $report['mp_already_paid']++;
+        continue;
+    }
+    if ($status !== 'pending') {
+        $report['skipped'][] = ['id' => $p['id'] ?? null, 'reason' => 'status=' . $status];
+        continue;
+    }
+    // Defensive: only migrate rows where we have a payment_id, which means
+    // the webhook actually saved the row after MP confirmed 'approved'.
+    // A row without payment_id may have come from elsewhere -> skip.
+    if (empty($p['payment_id'])) {
+        $report['mp_missing_payment_id']++;
+        $report['skipped'][] = ['id' => $p['id'] ?? null, 'reason' => 'no payment_id'];
+        continue;
+    }
+
+    $report['mp_pending']++;
+    $report['migrated_ids'][] = [
+        'id'         => $p['id'] ?? null,
+        'user_email' => $p['user_email'] ?? null,
+        'amount_clp' => $p['amount_clp'] ?? $p['amount'] ?? null,
+        'description'=> $p['description'] ?? null,
+        'payment_id' => $p['payment_id'] ?? null,
+        'date'       => $p['date'] ?? null
+    ];
+
+    if (!$DRY_RUN) {
+        $data['purchases'][$i]['status'] = 'paid';
+        $data['purchases'][$i]['status_fixed_by_migration'] = [
+            'at' => $nowIso,
+            'from' => 'pending',
+            'script' => 'fix_mercadopago_purchases.php'
+        ];
+    }
+}
+
+if (!$DRY_RUN && $report['mp_pending'] > 0) {
+    // Backup before writing
+    $backup = __DIR__ . '/purchases_backup_mp_fix_' . date('Y-m-d_H-i-s') . '.json';
+    if (file_put_contents($backup, $raw) === false) {
+        echo json_encode(['error' => 'Failed to write backup file. Aborting without changing purchases.json.', 'attempted_backup' => $backup]);
+        exit;
+    }
+    $report['backup_file'] = $backup;
+    file_put_contents($purchasesFile, json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+}
+
+echo json_encode($report, JSON_PRETTY_PRINT);

--- a/api/mercadopago.php
+++ b/api/mercadopago.php
@@ -263,7 +263,12 @@ function handleWebhook() {
                 'payment_method' => 'mercadopago',
                 'payment_id' => $paymentId,
                 'order_id' => $externalRef,
-                'status' => 'pending'
+                // This branch only runs when MercadoPago already confirmed
+                // payment.status === 'approved' (see the if-guard ~30 lines
+                // above). The local record must reflect that as 'paid';
+                // previously hardcoded to 'pending' which left the admin
+                // Compras page showing paid orders perpetually as PENDING.
+                'status' => 'paid'
             ]);
             
             if (empty($purchase['_duplicate'])) {


### PR DESCRIPTION
## Bug

Every MercadoPago purchase in admin `/panel/admin/#/purchases` shows **PENDING** in yellow, even though MP already confirmed the payment server-side and the money is in the merchant account. Examples in production today:

```
pur_69f7d5f9   ricardo.poblete    $9.900    mercadopago   PENDING
pur_69f53109   gaaguirrem         $29.700   mercadopago   PENDING
pur_699665ac   info@tourevo.cl    $9.900    mercadopago   PENDING
pur_69894d08   drsvigueras        $39.600   mercadopago   PENDING
pur_69a78665   jmolinal           $189.600  mercadopago   PENDING
```

WebPay purchases show **PAID** correctly.

## Root cause

`api/mercadopago.php` `handleWebhook()` enters its save branch ONLY inside this guard (line ~234):

```php
if (($payment['status'] ?? '') === 'approved' && isset($payment['payer']['email'])) {
    ...
    $purchase = savePurchase([
        ...
        'status' => 'pending'   // ← hardcoded, ignores the 'approved' guard
    ]);
```

So **every MP row in `purchases.json` is actually paid** — the webhook only runs after a server-side `curl` to `api.mercadopago.com/v1/payments` returns `'approved'`. The local label being `'pending'` was purely a display lie; the money was always received.

This is the same bug shape WebPay had (already fixed via `api/fix_webpay_purchases.php`). `webpay.php:343` correctly stores `'status' => 'paid'`.

## Fix

### 1) `api/mercadopago.php`
Change the hardcoded `'status' => 'pending'` to `'status' => 'paid'`. The if-guard already proves MP approved. Added inline comment so the bug isn't reintroduced.

### 2) `api/fix_mercadopago_purchases.php` (NEW)
One-shot migration script to flip existing rows:
- For every row where `payment_method='mercadopago'` AND `status='pending'` AND `payment_id != ''` → set `status='paid'`
- The `payment_id != ''` guard is defensive: only rows the webhook actually saved (i.e. MP confirmed `'approved'` at save time) are touched
- Timestamped backup of `purchases.json` before writing. Refuses to proceed if backup write fails
- **Idempotent**: second run reports `mp_pending=0` and doesn't write
- Audit trail: each migrated row gets a `status_fixed_by_migration` object
- Browser invocation gated by `?key=MIGRATION_KEY_2026` (same pattern as the WebPay fixer)
- CLI default = dry-run; pass `--apply` to write. Browser default = apply; pass `&dry=1` for dry-run

## Verified locally

```
5 rows (1 webpay, 4 mercadopago)
dry-run  -> reports 2 candidates, file untouched
apply    -> migrates 2 MP+pending+payment_id rows; skips already-paid + no-payment_id
re-run   -> mp_pending=0, no writes (idempotent)
webpay row untouched throughout
```

## Test plan
- [ ] After deploy, hit `/api/fix_mercadopago_purchases.php?key=MIGRATION_KEY_2026&dry=1` and verify the report shows the ~5 expected PENDING rows.
- [ ] Hit `/api/fix_mercadopago_purchases.php?key=MIGRATION_KEY_2026` (no `dry=1`) to apply.
- [ ] Refresh admin Compras page → those 5 rows now show PAID.
- [ ] Make a new test MP payment → the new purchase appears as PAID immediately (fix-forward).

https://claude.ai/code/session_01GqCGWuyhatt6tWJcscpwrC

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqCGWuyhatt6tWJcscpwrC)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jpchs1/imporlan/pull/534" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->