### PR TITLE
migrate-imporlan-to-own-folder.sh: tar fallback when rsync missing

### DIFF
--- a/migrate-imporlan-to-own-folder.sh
+++ b/migrate-imporlan-to-own-folder.sh
@@ -126,17 +126,42 @@ if [ "$MODE" = "apply" ]; then
   mkdir -p "$DST"
 fi
 
-# -------- rsync --------
-EXCLUDE_ARGS=()
-for x in "${EXCLUDES[@]}"; do EXCLUDE_ARGS+=(--exclude="$x"); done
+# -------- copy: prefer rsync, fall back to tar --------
+# Shared hosting often doesn't ship rsync; tar is universally available
+# and supports --exclude patterns the same way.
+echo ""
+echo "[2/4] Copying files (mode: $MODE) ..."
+echo "      Logging to $LOG"
 
-echo ""
-echo "[2/4] rsyncing files (mode: $MODE) ..."
-echo "      tee'ing output to $LOG"
-echo ""
-rsync -av $RSYNC_FLAG \
-  "${EXCLUDE_ARGS[@]}" \
-  "$SRC/" "$DST/" 2>&1 | tee "$LOG" | tail -40
+if command -v rsync >/dev/null 2>&1; then
+  echo "      Using rsync"
+  EXCLUDE_ARGS=()
+  for x in "${EXCLUDES[@]}"; do EXCLUDE_ARGS+=(--exclude="$x"); done
+  rsync -av $RSYNC_FLAG \
+    "${EXCLUDE_ARGS[@]}" \
+    "$SRC/" "$DST/" 2>&1 | tee "$LOG" | tail -40
+else
+  echo "      rsync not available, using tar"
+  TAR_EXCLUDES=()
+  for x in "${EXCLUDES[@]}"; do
+    # tar wants ./pattern relative to the source CWD and no trailing slash
+    TAR_EXCLUDES+=(--exclude="./${x%/}")
+  done
+  if [ "$MODE" = "dry-run" ]; then
+    # tar can't really dry-run a copy, but we can list what it WOULD
+    # archive (excludes applied), which mirrors what would be copied.
+    ( cd "$SRC" && tar -cvf /dev/null "${TAR_EXCLUDES[@]}" . ) 2>&1 \
+      | tee "$LOG" | tail -40
+    echo "      (dry-run: nothing was written to $DST)"
+  else
+    # Stream tar from SRC into tar -x at DST. Preserves perms + times.
+    # Status is written to stderr; ignore non-fatal warnings about
+    # the .htaccess file changing during read etc.
+    ( cd "$SRC" && tar -cf - "${TAR_EXCLUDES[@]}" . ) \
+      | ( cd "$DST" && tar -xf - ) 2>>"$LOG"
+    echo "      tar copy complete (see $LOG for any warnings)"
+  fi
+fi
 echo ""
 
 # -------- post-copy validation (only when applied) --------


### PR DESCRIPTION
## Bug

Banahosting shared hosting (where Imporlan runs) doesn't ship `rsync`. Confirmed live: the user ran the migration dry-run and got:

```
[2/4] rsyncing files (mode: dry-run) ...
/home/wwimpo/migrate-imporlan-to-own-folder.sh: line 137: rsync: command not found
```

The script was unrunnable on the only environment it was designed for.

## Fix

Detect `rsync` availability and fall back to `tar` when absent. `tar` is universally available on cPanel-style shared hosting and supports `--exclude` patterns the same way.

```bash
if command -v rsync >/dev/null 2>&1; then
  rsync -av $RSYNC_FLAG "${EXCLUDE_ARGS[@]}" "$SRC/" "$DST/"
else
  # tar fallback
  ( cd "$SRC" && tar -cf - "${TAR_EXCLUDES[@]}" . ) \
    | ( cd "$DST" && tar -xf - )
fi
```

For dry-run with tar, we use `tar -cvf /dev/null` which archives nothing (output to /dev/null) but still prints the file list it WOULD archive on stderr — same review value as `rsync -n`.

Pre-flight analysis (which already worked) and post-copy validation are unchanged. The pre-flight already gave the user useful info:

```
[pre-flight] /home/wwimpo/public_html/index.html looks like Imporlan: OK
[pre-flight] /home/wwimpo/public_html total size: 422M
[pre-flight] Tourevo strays currently present in /home/wwimpo/public_html (will be SKIPPED):
    - tours/ (1.2M)
    - assets/tours/ (15M)
    - assets/fleet/ (2.3M)
    - assets/photo-service/ (2.0M)
    - cgi-bin/ (4.0K)
    - .well-known/acme-challenge/ (4.0K)
```

## Verified locally

Direct test of the tar block with a 6-file fixture (3 Imporlan + 3 Tourevo strays):

```
SRC: index.html, panel/index.html, assets/file1.js,
     tourevo/x.html, assets/tours/x.jpg, assets/fleet/x.jpg
DST after tar: index.html, panel/index.html, assets/file1.js
                ← all 3 Imporlan files, zero Tourevo strays
```

Perms + timestamps preserved (default tar behaviour).

## Test plan
- [ ] User re-downloads the script + re-runs `bash ~/migrate-imporlan-to-own-folder.sh` (dry-run). Output shows `Using tar` and lists what it would copy.
- [ ] User runs `--apply`. Output shows `tar copy complete`.
- [ ] `~/imporlan.cl/` is populated with Imporlan content; `~/public_html/` untouched.
- [ ] `diff -rq ~/public_html/ ~/imporlan.cl/ | head -20` shows only the excluded Tourevo paths.

https://claude.ai/code/session_01GqCGWuyhatt6tWJcscpwrC

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqCGWuyhatt6tWJcscpwrC)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jpchs1/imporlan/pull/535" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->