### PR TITLE
migrate-imporlan-to-own-folder.sh: invert EXCLUDES → INCLUDES manifest

### DIFF
--- a/migrate-imporlan-to-own-folder.sh
+++ b/migrate-imporlan-to-own-folder.sh
@@ -2,27 +2,29 @@
 # ============================================
 #  migrate-imporlan-to-own-folder.sh
 # ============================================
-#  Stage Imporlan's content into its own ~/imporlan.cl/ directory in
-#  preparation for banahosting changing the imporlan.cl Document Root
-#  from /public_html to /imporlan.cl.
+#  Stage Imporlan's content into ~/imporlan.cl/ in preparation for
+#  banahosting changing the imporlan.cl Document Root from /public_html
+#  to /imporlan.cl. Pre-populating ahead of time means the switch is
+#  transparent to users (zero perceived downtime).
 #
-#  Until banahosting applies the change, ~/public_html/ remains the
-#  live doc-root and this script does NOT touch it -- it only rsyncs
-#  a COPY of the Imporlan files into ~/imporlan.cl/.
+#  STRATEGY -- INCLUSION LIST, NOT EXCLUSION
+#  ------------------------------------------
+#  ~/public_html/ is currently a mixed bag: Imporlan content + Tourevo
+#  stragglers + ambiguous shared stuff (favicons, llms.txt, etc.).
 #
-#  After banahosting confirms the docroot switch, the new ~/imporlan.cl/
-#  takes over and ~/public_html/ becomes a parking placeholder.
+#  Instead of trying to enumerate everything we DON'T want, we
+#  enumerate exactly what we DO want -- the Imporlan production
+#  manifest (49 directories + 1 PDF lib + a handful of root files
+#  that are present in the github.com/jpchs1/Imporlan repo).
+#
+#  Anything not on the list is left untouched at ~/public_html/.
+#  This is safer than excludes because if Tourevo's deploys drop new
+#  random directories in the future, they won't auto-leak into our
+#  fresh imporlan.cl/ folder.
 #
 #  USAGE
-#    bash migrate-imporlan-to-own-folder.sh           # dry-run + analysis (DEFAULT)
-#    bash migrate-imporlan-to-own-folder.sh --apply   # actually do the rsync
-#
-#  EXIT CODES
-#    0  -> ok
-#    1  -> source missing
-#    2  -> source doesn't look like Imporlan (refusing to copy)
-#    3  -> destination validation failed after rsync
-#    4  -> destination index.html doesn't look like Imporlan after rsync
+#    bash migrate-imporlan-to-own-folder.sh           # dry-run + report (default)
+#    bash migrate-imporlan-to-own-folder.sh --apply   # actually copy
 # ============================================
 set -euo pipefail
 
@@ -32,38 +34,77 @@ TIMESTAMP=$(date +%Y-%m-%d_%H%M%S)
 BACKUP_DIR="/home/wwimpo/backups"
 LOG="/home/wwimpo/imporlan-migration-$TIMESTAMP.log"
 
-# Default mode is dry-run. Pass --apply to actually copy.
 MODE="dry-run"
-RSYNC_FLAG="-n"
-if [ "${1:-}" = "--apply" ]; then
-  MODE="apply"
-  RSYNC_FLAG=""
-fi
+if [ "${1:-}" = "--apply" ]; then MODE="apply"; fi
 
-# Paths in ~/public_html/ that belong to OTHER sites (Tourevo stragglers from
-# previous mis-targeted deploys) -- excluded from the copy so ~/imporlan.cl/
-# stays clean. They remain at $SRC for the Tourevo team to clean up
-# separately; they were never Imporlan's to begin with.
-EXCLUDES=(
-  # known Tourevo stragglers we've identified
-  "tourevo/"
-  "tours/"
-  "fleet/"
-  "photo-service/"
-  "assets/tours/"
-  "assets/fleet/"
-  "assets/photo-service/"
-  ".tourevo*"
-  # server-managed / cPanel-managed -- leave at source
-  ".user.ini"
-  "cgi-bin/"
-  ".cpanel/"
-  ".trash/"
-  "tmp/"
-  ".well-known/acme-challenge/"
-  # nothing in build artefacts should sneak in
-  "node_modules/"
-  ".git/"
+# --------------------------------------------------------------------
+# Imporlan production manifest
+# Source of truth: github.com/jpchs1/Imporlan main branch top-level
+# directories (49) + lib/ (server-only, used by cotizador-importacion
+# for dompdf PDF rendering) + the 5 root files the repo ships +
+# .htaccess (managed by the Imporlan repo).
+# --------------------------------------------------------------------
+IMPORLAN_DIRS=(
+  admin-react
+  api
+  assets
+  botes-de-pesca
+  casos-de-importacion
+  como-comprar-lancha-usada-chile
+  como-vender-moto-de-agua-chile
+  comprar-lanchas-usadas-en-chile-o-en-usa
+  costo-mantener-lancha-chile
+  cotizador-importacion
+  cotizar-importacion
+  cuanto-cuesta-importar-una-lancha-a-chile
+  documentos-tramites-vender-embarcacion-chile
+  embarcaciones
+  embarcaciones-usadas
+  images
+  importacion-embarcaciones-usa-chile
+  importacion-lanchas-chile
+  importacion-veleros-chile
+  importaciones
+  importar-embarcaciones-usa
+  importar-motos-de-agua-desde-usa
+  inspeccion-precompra-embarcaciones
+  lanchas
+  lanchas-de-pesca-usadas
+  lanchas-de-ski
+  lanchas-usadas
+  lanchas-usadas-baratas-chile
+  lanchas-usadas-en-chile-2
+  lanchas-usadas-marcas
+  lanchas-usadas-santiago
+  lib
+  logistica-maritima-importacion
+  marketplace
+  mejores-lanchas-usadas-chile
+  pago
+  panel
+  panel-test
+  precio-lanchas-usadas-chile
+  preguntas-frecuentes-embarcaciones-usadas
+  requisitos-importar-embarcaciones-chile
+  seguro-embarcaciones-chile
+  servicios
+  servicios-importacion
+  simulacion-cotizacion
+  t
+  test
+  tipos-de-lanchas-segun-uso
+  transporte-logistica-embarcaciones-chile
+  veleros-usados
+  veleros-usados-a-la-venta-en-chile-o-usa
+)
+
+IMPORLAN_FILES=(
+  .htaccess
+  favicon.ico
+  index.html
+  marketplace.html
+  robots.txt
+  sitemap.xml
 )
 
 echo "==============================================================="
@@ -76,47 +117,86 @@ echo "  Destination: $DST"
 echo "  Mode:        $MODE"
 echo "  Log:         $LOG"
 echo ""
-echo "  Excluded paths (Tourevo / cPanel / server-managed):"
-for x in "${EXCLUDES[@]}"; do echo "    - $x"; done
+echo "  Strategy: inclusion list (only Imporlan paths copied)."
+echo "  Anything else at $SRC stays where it is."
 echo ""
 
-# -------- pre-flight: source must exist + look like Imporlan --------
+# --------------------------------------------------------------------
+# Pre-flight: source must exist and look like Imporlan
+# --------------------------------------------------------------------
 if [ ! -d "$SRC" ]; then
   echo "ERROR: $SRC does not exist."
   exit 1
 fi
 if [ ! -f "$SRC/index.html" ] || ! grep -qiE 'imporlan|Importaci[oó]n de Lanchas' "$SRC/index.html"; then
   echo "ERROR: $SRC/index.html does not look like Imporlan."
-  echo "       Refusing to copy -- the source may be in a bad state."
-  echo "       Restore index.html first, then re-run."
+  echo "       Refusing to copy."
   exit 2
 fi
 echo "[pre-flight] $SRC/index.html looks like Imporlan: OK"
-
-# -------- analysis: how big? what Tourevo strays are in source? --------
-SIZE_TOTAL=$(du -sh "$SRC" 2>/dev/null | awk '{print $1}')
-echo "[pre-flight] $SRC total size: $SIZE_TOTAL"
+echo "[pre-flight] $SRC total size: $(du -sh "$SRC" 2>/dev/null | awk '{print $1}')"
 echo ""
-echo "[pre-flight] Tourevo strays currently present in $SRC (will be SKIPPED):"
-for x in "${EXCLUDES[@]}"; do
-  PATH_CHECK="${SRC%/}/${x%/}"
-  if [ -e "$PATH_CHECK" ]; then
-    SIZE=$(du -sh "$PATH_CHECK" 2>/dev/null | awk '{print $1}')
-    echo "    - $x ($SIZE)"
+
+# --------------------------------------------------------------------
+# Verify each manifest entry exists at $SRC and report
+# --------------------------------------------------------------------
+echo "[manifest] Imporlan directories that will be copied:"
+MISSING=()
+TOTAL_SIZE=0
+for d in "${IMPORLAN_DIRS[@]}"; do
+  if [ -d "$SRC/$d" ]; then
+    SIZE=$(du -sh "$SRC/$d" 2>/dev/null | awk '{print $1}')
+    printf "    OK %-55s %s\n" "$d/" "$SIZE"
+  else
+    printf "    -- %-55s (not present, skipping)\n" "$d/"
+    MISSING+=("$d")
   fi
 done
+
+echo ""
+echo "[manifest] Imporlan root files that will be copied:"
+for f in "${IMPORLAN_FILES[@]}"; do
+  if [ -f "$SRC/$f" ]; then
+    SIZE=$(du -h "$SRC/$f" 2>/dev/null | awk '{print $1}')
+    printf "    OK %-55s %s\n" "$f" "$SIZE"
+  else
+    printf "    -- %-55s (not present, skipping)\n" "$f"
+    MISSING+=("$f")
+  fi
+done
+
+echo ""
+echo "[manifest] Items at $SRC that will be LEFT BEHIND"
+echo "           (not in the Imporlan manifest -- could be Tourevo or"
+echo "            third-party files; we don't move what we don't own):"
+( cd "$SRC" && ls -1A ) | while read item; do
+  KNOWN=0
+  for d in "${IMPORLAN_DIRS[@]}" "${IMPORLAN_FILES[@]}"; do
+    if [ "$item" = "$d" ]; then KNOWN=1; break; fi
+  done
+  if [ "$KNOWN" -eq 0 ]; then
+    if [ -d "$SRC/$item" ]; then
+      SIZE=$(du -sh "$SRC/$item" 2>/dev/null | awk '{print $1}')
+      printf "    -- %-55s %s\n" "$item/" "$SIZE"
+    else
+      printf "    -- %-55s (file)\n" "$item"
+    fi
+  fi
+done
+
 echo ""
 
-# -------- confirm if --apply --------
+# --------------------------------------------------------------------
+# Confirm if --apply
+# --------------------------------------------------------------------
 if [ "$MODE" = "apply" ]; then
-  echo "About to rsync $SRC -> $DST"
+  echo "About to copy the Imporlan manifest items from $SRC into $DST"
   if [ -d "$DST" ]; then
     echo "WARNING: $DST already exists. It will be backed up first."
   fi
   read -p "Type 'yes' to proceed: " ANS
   [ "$ANS" = "yes" ] || { echo "Aborted by user."; exit 0; }
 
-  # Backup any pre-existing imporlan.cl folder
   if [ -d "$DST" ]; then
     mkdir -p "$BACKUP_DIR"
     EXISTING_BACKUP="$BACKUP_DIR/imporlan.cl_pre_migration_$TIMESTAMP"
@@ -126,64 +206,66 @@ if [ "$MODE" = "apply" ]; then
   mkdir -p "$DST"
 fi
 
-# -------- copy: prefer rsync, fall back to tar --------
-# Shared hosting often doesn't ship rsync; tar is universally available
-# and supports --exclude patterns the same way.
-echo ""
-echo "[2/4] Copying files (mode: $MODE) ..."
+# --------------------------------------------------------------------
+# Build the tar argument list (only items that exist at $SRC)
+# --------------------------------------------------------------------
+TAR_ARGS=()
+for d in "${IMPORLAN_DIRS[@]}"; do
+  [ -d "$SRC/$d" ] && TAR_ARGS+=("./$d")
+done
+for f in "${IMPORLAN_FILES[@]}"; do
+  [ -f "$SRC/$f" ] && TAR_ARGS+=("./$f")
+done
+
+if [ ${#TAR_ARGS[@]} -eq 0 ]; then
+  echo "ERROR: nothing to copy (no manifest items found at $SRC)."
+  exit 4
+fi
+
+# --------------------------------------------------------------------
+# Copy (prefer rsync, fall back to tar)
+# --------------------------------------------------------------------
+echo "[2/4] Copying ${#TAR_ARGS[@]} manifest items (mode: $MODE) ..."
 echo "      Logging to $LOG"
 
 if command -v rsync >/dev/null 2>&1; then
   echo "      Using rsync"
-  EXCLUDE_ARGS=()
-  for x in "${EXCLUDES[@]}"; do EXCLUDE_ARGS+=(--exclude="$x"); done
-  rsync -av $RSYNC_FLAG \
-    "${EXCLUDE_ARGS[@]}" \
-    "$SRC/" "$DST/" 2>&1 | tee "$LOG" | tail -40
+  RSYNC_FLAG=""
+  [ "$MODE" = "dry-run" ] && RSYNC_FLAG="-n"
+  RSYNC_PATHS=()
+  for p in "${TAR_ARGS[@]}"; do RSYNC_PATHS+=("$SRC/${p#./}"); done
+  rsync -av $RSYNC_FLAG "${RSYNC_PATHS[@]}" "$DST/" 2>&1 | tee "$LOG" | tail -40
 else
   echo "      rsync not available, using tar"
-  TAR_EXCLUDES=()
-  for x in "${EXCLUDES[@]}"; do
-    # tar wants ./pattern relative to the source CWD and no trailing slash
-    TAR_EXCLUDES+=(--exclude="./${x%/}")
-  done
   if [ "$MODE" = "dry-run" ]; then
-    # tar can't really dry-run a copy, but we can list what it WOULD
-    # archive (excludes applied), which mirrors what would be copied.
-    ( cd "$SRC" && tar -cvf /dev/null "${TAR_EXCLUDES[@]}" . ) 2>&1 \
-      | tee "$LOG" | tail -40
+    ( cd "$SRC" && tar -cvf /dev/null "${TAR_ARGS[@]}" ) 2>&1 | tee "$LOG" | tail -40
     echo "      (dry-run: nothing was written to $DST)"
   else
-    # Stream tar from SRC into tar -x at DST. Preserves perms + times.
-    # Status is written to stderr; ignore non-fatal warnings about
-    # the .htaccess file changing during read etc.
-    ( cd "$SRC" && tar -cf - "${TAR_EXCLUDES[@]}" . ) \
+    ( cd "$SRC" && tar -cf - "${TAR_ARGS[@]}" ) \
       | ( cd "$DST" && tar -xf - ) 2>>"$LOG"
     echo "      tar copy complete (see $LOG for any warnings)"
   fi
 fi
 echo ""
 
-# -------- post-copy validation (only when applied) --------
+# --------------------------------------------------------------------
+# Post-copy validation (only when applied)
+# --------------------------------------------------------------------
 if [ "$MODE" = "apply" ]; then
   echo "[3/4] Validating $DST ..."
   if [ ! -f "$DST/index.html" ]; then
-    echo "ERROR: $DST/index.html missing after rsync."
+    echo "ERROR: $DST/index.html missing after copy."
     exit 3
   fi
   if ! grep -qiE 'imporlan|Importaci[oó]n de Lanchas' "$DST/index.html"; then
-    echo "ERROR: $DST/index.html doesn't look like Imporlan after rsync."
+    echo "ERROR: $DST/index.html doesn't look like Imporlan after copy."
     exit 4
   fi
   echo "      OK index.html present and looks like Imporlan"
-
-  # Sample of key directories
   for d in assets panel api images cotizar-importacion lanchas-usadas marketplace; do
     if [ -d "$DST/$d" ]; then
       COUNT=$(find "$DST/$d" -type f 2>/dev/null | wc -l)
       echo "      OK $d/ present ($COUNT files)"
-    else
-      echo "      MISSING $d/"
     fi
   done
 
@@ -192,7 +274,7 @@ if [ "$MODE" = "apply" ]; then
   cat > "$DST/.imporlan_docroot" <<SENTINEL_EOF
 Imporlan doc-root.
 Staged via migrate-imporlan-to-own-folder.sh on $TIMESTAMP.
-Origin: $SRC
+Origin: $SRC (only Imporlan manifest items copied; rest left at origin).
 DO NOT DELETE -- deploy scripts check for this sentinel before writing.
 SENTINEL_EOF
   chmod 644 "$DST/.imporlan_docroot"
@@ -208,33 +290,37 @@ if [ "$MODE" = "dry-run" ]; then
   cat <<NEXT
   This was a DRY RUN. No files were copied.
 
+  Review the "manifest" sections above:
+    - "OK" lines under "Imporlan directories" / "root files" = will be copied
+    - "--" lines under "LEFT BEHIND" = will stay at $SRC (untouched)
+
   To apply for real:
     bash $0 --apply
-
 NEXT
 else
   cat <<NEXT
-  Files were copied. $SRC is UNTOUCHED.
+  Imporlan files were copied to $DST.
+  $SRC is UNTOUCHED -- non-Imporlan content remains there.
 
-  NEXT STEPS (in this order):
+  NEXT STEPS:
 
-  1. Spot-check $DST manually:
+  1. Sanity check $DST:
        ls $DST/
-       diff -rq $SRC/ $DST/ | head -30   # should only show the EXCLUDED Tourevo paths
+       du -sh $DST/
 
-  2. Reply to banahosting confirming you have the content staged and
-     ask them to apply the docroot switch:
+  2. Reply to banahosting asking them to apply the docroot switch:
         /home/wwimpo/public_html  ->  /home/wwimpo/imporlan.cl
 
-  3. After banahosting confirms the switch:
-       curl -sL https://www.imporlan.cl/ | grep -oE '<title>[^<]+</title>'
-       # should still show the Imporlan title
+  3. After banahosting confirms:
+       curl -sL "https://www.imporlan.cl/?cb=\$(date +%s)" \\
+         | grep -oE '<title>[^<]+</title>'
 
   4. Update auto-deploy.sh:
        sed -i 's#PUBLIC_HTML="/home/wwimpo/public_html"#PUBLIC_HTML="/home/wwimpo/imporlan.cl"#' \\
          /home/wwimpo/auto-deploy.sh
 
-  5. Once verified for ~24h, you can clean $SRC (or leave it as parking).
-
+  5. Once verified for ~24h, you can decide what to do with the
+     leftover content at $SRC (it stays there, untouched -- the new
+     docroot ignores it).
 NEXT
 fi


### PR DESCRIPTION
## Why

User inspected `~/public_html/` via cPanel and found it's a mixed bag: Imporlan + Tourevo SEO pages (`private-tours-...`, `tour-privado-...`, `tours-privados-...`) + Tourevo subfolders (`tourevo/`, `tours/`, `fleet/`, `rentacarchile/`, `transfers/`, `br/`, `en/`, `wp-content/`) + ambiguous shared resources (`about/`, `blog/`, `contact/`, `css/`, `faq/`, `js/`).

User direction: *"Solo llevate imporlan si hay algo de algun otro sitio debes dejarlo en su carpeta y sitio correspondiente."*

The previous EXCLUDES approach (enumerate what NOT to copy) was the wrong shape for that constraint — requires knowing every non-Imporlan path in advance, and silently leaks anything new that a future Tourevo deploy adds.

## What

Inverted to **INCLUDES** manifest. Enumerate only what belongs to Imporlan:

- **49 production directories** (intersection of `github.com/jpchs1/Imporlan` main top-level dirs ∩ what's actually in `~/public_html/`)
- **`lib/`** (hosts dompdf for `cotizador-importacion` PDF rendering — server-only, referenced by `cotizador-importacion/index.php`)
- **5 root files** (`favicon.ico`, `index.html`, `marketplace.html`, `robots.txt`, `sitemap.xml`)
- **`.htaccess`** (Imporlan-managed)

Everything else at `~/public_html/` is reported in a new `LEFT BEHIND` section and **stays untouched**. Tourevo content, ambiguous content, backups, third-party files — none are moved or copied. They remain exactly where Apache currently serves them.

## New report sections

```
[manifest] Imporlan directories that will be copied:
    OK api/                                                    8.0K
    -- botes-de-pesca/                                         (not present, skipping)
    OK panel/                                                  12M
    ...

[manifest] Imporlan root files that will be copied:
    OK .htaccess                                               4.0K
    OK index.html                                              4.0K
    ...

[manifest] Items at ~/public_html/ that will be LEFT BEHIND
           (not in the Imporlan manifest -- could be Tourevo or
            third-party files; we don't move what we don't own):
    -- tourevo/                                                4.5M
    -- tour-privado-vina-concha-y-toro/                        180K
    -- wp-content/                                             ...
    -- index.html.tourevo-backup-1778531519                    (file)
    ...
```

Operator can review the LEFT BEHIND section before applying and confirm nothing important is missing from the Imporlan manifest.

## Smoke tested

Fixture: 7 Imporlan dirs + 5 Imporlan root files + 10 Tourevo dirs + 6 ambiguous dirs + 2 stray files.

After `--apply`:
- DST received exactly the 13 manifest items + `.imporlan_docroot` sentinel
- SRC untouched (all 10 Tourevo dirs + 6 ambiguous dirs + 2 stray files remained)
- `index.html` validated post-copy ("looks like Imporlan")

## Files
- `migrate-imporlan-to-own-folder.sh` — full rewrite (+193 / -107 lines)

## Test plan
- [ ] User downloads fresh script via `git clone`.
- [ ] User runs `bash migrate-imporlan-to-own-folder.sh` (dry-run). Reviews the three manifest sections.
- [ ] LEFT BEHIND should list: `about`, `blog`, `br`, `contact`, `cotizador`, `css`, `datos-empresa`, `en`, `faq`, `fotografia`, `fotos`, `guia-city-tour-...`, `js`, `log`, `opciones-de-cancelacion`, `opiniones`, `partners`, `press`, `private-tours-...`, `rentacarchile`, `resenas`, `terminos-y-condiciones`, `tools`, `tourevo-agencia-...`, `tour-privado-...`(9), `tours`, `tours-privados-...`, `trabaja-con-nosotros`, `transfers`, `turismo-receptivo-...`, `uploads`, `USOperations`, `wp-content`, plus stray files (`_redirects`, `apple-touch-icon.png`, `email1_body.html`, `favicon-*`, `google*.html`, `index.html.tourevo-backup-*`, `llms-*.txt`, `og-image.*`, `site.webmanifest`, `sitemap-seo.xml`, `tourevo_mailer.php`).
- [ ] User runs `--apply`. `~/imporlan.cl/` ends up with only the manifest items.
- [ ] `ls ~/public_html/` is unchanged (Tourevo + everything else still there).

https://claude.ai/code/session_01GqCGWuyhatt6tWJcscpwrC

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqCGWuyhatt6tWJcscpwrC)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jpchs1/imporlan/pull/536" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->