### PR TITLE
migrate manifest: add runtime dirs (.admin_profiles, .admin_reset_tokens, uploads)

### DIFF
--- a/migrate-imporlan-to-own-folder.sh
+++ b/migrate-imporlan-to-own-folder.sh
@@ -96,6 +96,19 @@ IMPORLAN_DIRS=(
   transporte-logistica-embarcaciones-chile
   veleros-usados
   veleros-usados-a-la-venta-en-chile-o-usa
+  # Server-side runtime dirs (NOT in the github repo, but written by
+  # Imporlan PHP at runtime and required for /panel/admin and the
+  # cotizador image cache to keep working after the doc-root switch):
+  #   .admin_profiles    - written by api/admin_profile.php + api/admin_avatar.php
+  #                        (admin user profiles + avatar images)
+  #   .admin_reset_tokens - written by api/admin_forgot_password.php +
+  #                         api/admin_reset_password.php (password reset)
+  #   uploads            - written by api/image_cache.php +
+  #                        api/link_scraper.php (cached boat photos served
+  #                        from https://www.imporlan.cl/uploads/order_images/)
+  .admin_profiles
+  .admin_reset_tokens
+  uploads
 )
 
 IMPORLAN_FILES=(


### PR DESCRIPTION
User ran dry-run and the LEFT BEHIND section flagged 3 dirs that grep against the api/ code confirmed are Imporlan-owned (server-side runtime state, not checked into the github repo because they're gitignored).

  `.admin_profiles/` (1.6M) — `api/admin_profile.php` + `api/admin_avatar.php` (admin user profiles + avatar images)
  `.admin_reset_tokens/` (8.0K) — `api/admin_forgot_password.php` + `api/admin_reset_password.php` (password reset tokens)
  `uploads/` (21M) — `api/image_cache.php` + `api/link_scraper.php` (cached boat photos served from `https://www.imporlan.cl/uploads/order_images/`)

Without these, after the docroot switch the panel admin loses every admin's profile + avatar, password resets break in-flight, and every cached order image becomes 404.

Confirmed NOT Imporlan via grep (left at SRC):
  `log/`, `USOperations/`, `.tmb/`, `.well-known/`, `.nojekyll`

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqCGWuyhatt6tWJcscpwrC)_