### PR TITLE
Cotizador: include main listing image in quote-ready email

### DIFF
--- a/api/cotizador_helpers.php
+++ b/api/cotizador_helpers.php
@@ -194,6 +194,21 @@ if (!defined('IMPORLAN_COTIZADOR_HELPERS_LOADED')) {
             $subject = 'Tu cotización está lista — ' . $title;
             $panelUrl = 'https://www.imporlan.cl/panel/';
 
+            // Hero image — the main listing image scraped/uploaded for this link.
+            // Wrapped in an anchor to the original listing URL when present so the
+            // client can jump back to the source ad. Skipped silently if either is
+            // missing or fails URL validation.
+            $imageUrl = trim((string)($link['image_url'] ?? ''));
+            $listingUrl = trim((string)($link['url'] ?? ''));
+            $imageBlock = '';
+            if ($imageUrl !== '' && filter_var($imageUrl, FILTER_VALIDATE_URL)) {
+                $img = '<img src="' . htmlspecialchars($imageUrl) . '" alt="' . htmlspecialchars($title) . '" width="560" style="display:block;width:100%;max-width:560px;height:auto;border:0;border-radius:10px;object-fit:cover" />';
+                if ($listingUrl !== '' && filter_var($listingUrl, FILTER_VALIDATE_URL)) {
+                    $img = '<a href="' . htmlspecialchars($listingUrl) . '" target="_blank" style="text-decoration:none;color:inherit">' . $img . '</a>';
+                }
+                $imageBlock = '<div style="margin:0 0 18px;border-radius:10px;overflow:hidden">' . $img . '</div>';
+            }
+
             // Decode the quote_data snapshot so we can render the same itemized
             // breakdown the admin sees in the QuoteModal (Lancha, Servicio
             // All-Inclusive, IVA, Lujo, Total + 3 pagos).
@@ -259,7 +274,8 @@ if (!defined('IMPORLAN_COTIZADOR_HELPERS_LOADED')) {
 
             $html = '<!DOCTYPE html><html><body style="font-family:Arial,sans-serif;background:#f1f5f9;padding:20px">'
                 . '<div style="max-width:560px;margin:0 auto;background:#fff;border-radius:12px;padding:32px;box-shadow:0 2px 8px rgba(0,0,0,.08)">'
-                . '<h2 style="color:#1e293b;margin:0 0 8px">Tu cotización está lista</h2>'
+                . '<h2 style="color:#1e293b;margin:0 0 16px">Tu cotización está lista</h2>'
+                . $imageBlock
                 . '<p style="color:#475569;font-size:15px;line-height:1.6">Hola' . ($userName ? ' <strong>' . htmlspecialchars($userName) . '</strong>' : '') . ', ya terminamos el análisis de costos para <strong>' . htmlspecialchars($title) . '</strong>. Aquí va el resumen del valor final y el plan de pagos.</p>'
                 . '<div style="background:#f0f9ff;border:1px solid #bae6fd;padding:16px 18px;border-radius:10px;margin:18px 0">'
                 . '<div style="font-size:11px;color:#0369a1;text-transform:uppercase;letter-spacing:.05em;margin-bottom:4px">Resumen de costos</div>'

--- a/api/orders_api.php
+++ b/api/orders_api.php
@@ -1329,7 +1329,8 @@ function adminSaveQuote() {
                 // IVA, Lujo, plan de pagos) — without these columns the email
                 // would compute zeros and dump the whole total into All-Inclusive.
                 $info = $pdo->prepare("
-                    SELECT ol.id, ol.year, ol.make, ol.model, ol.quote_total_clp, ol.quote_total_usd,
+                    SELECT ol.id, ol.year, ol.make, ol.model, ol.image_url, ol.url,
+                           ol.quote_total_clp, ol.quote_total_usd,
                            ol.quote_data, ol.quote_payments,
                            o.customer_email, o.customer_name, o.order_number
                     FROM order_links ol


### PR DESCRIPTION
## Resumen

Los correos de "Tu cotización está lista" que se envían desde el admin panel al cliente ahora incluyen la **imagen principal del listado** (`order_links.image_url`) como hero arriba del resumen — clickeable hacia el link original. Mejora la referencia visual y el UI/UX del correo en los tres caminos de publicación.

## Cambios

- **`api/cotizador_helpers.php`** — `cotizadorSendReadyEmail()` renderiza `image_url` como hero responsivo (border-radius 10px, max-width 560px, object-fit cover). Si hay `url` del listado, envuelve la imagen en un `<a target="_blank">`. Validación con `FILTER_VALIDATE_URL` para skip silencioso si faltan/son inválidos.
- **`api/orders_api.php`** — `adminSaveQuote()` ahora hace SELECT de `ol.image_url, ol.url` para que el envío sincrónico al hacer "Guardar y enviar ahora" tenga los campos. Los otros dos caminos (lazy publish via `cotizadorApplyClientVisibility` y cron `cotizadorPublishDue`) ya pasan el row completo.

## Cobertura

Funciona en los 3 escenarios de envío:
1. "Guardar y enviar ahora" (sincrónico desde el modal de cotización)
2. Lazy publish cuando el cliente abre el panel después de las 24 hrs
3. Cron `cotizador_publish` cuando vence la ventana de delay

## Test plan

- [ ] Crear/editar cotización en admin → click "$" → "Guardar y enviar ahora"
- [ ] Verificar correo recibido contiene la imagen principal del link arriba del resumen
- [ ] Click sobre la imagen abre la URL original del aviso
- [ ] Test con link que tenga `image_url` vacío → email sigue funcionando sin imagen
- [ ] Test con "Guardar (24 hrs)" → al expirar la ventana el correo automático también incluye la imagen

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4VyxNVZgVAjhHNDDni2cW)_