### PR TITLE
docroot cutover: point deploy scripts to /home/wwimpo/imporlan.cl

### DIFF
--- a/.agents/skills/deployment/SKILL.md
+++ b/.agents/skills/deployment/SKILL.md
@@ -1,10 +1,10 @@
 # Deployment to IMPORLAN Servers
 
 ## Server Structure
-- **Test**: `https://www.imporlan.cl/panel-test/admin/` (files at `/public_html/panel-test/`)
-- **Production**: `https://www.imporlan.cl/panel/admin/` (files at `/public_html/panel/`)
-- **API (test)**: `https://www.imporlan.cl/test/api/` (files at `/public_html/test/api/`)
-- **API (prod)**: `https://www.imporlan.cl/api/` (files at `/public_html/api/`)
+- **Test**: `https://www.imporlan.cl/panel-test/admin/` (files at `/imporlan.cl/panel-test/`)
+- **Production**: `https://www.imporlan.cl/panel/admin/` (files at `/imporlan.cl/panel/`)
+- **API (test)**: `https://www.imporlan.cl/test/api/` (files at `/imporlan.cl/test/api/`)
+- **API (prod)**: `https://www.imporlan.cl/api/` (files at `/imporlan.cl/api/`)
 
 ## Deployment Method
 
@@ -20,7 +20,7 @@ url = "https://imporlan.cl:2083/execute/Fileman/upload_files"
 
 params = {
     'api.version': '1',
-    'dir': '/public_html/panel/admin/assets',  # target directory
+    'dir': '/imporlan.cl/panel/admin/assets',  # target directory
     'overwrite': '1',  # REQUIRED for existing files
 }
 with open('local/path/to/file.js', 'rb') as f:

--- a/.cpanel.yml
+++ b/.cpanel.yml
@@ -7,7 +7,7 @@ deployment:
     # ============================================
 
     # --- Variables ---
-    - export DEPLOYPATH=/home/wwimpo/public_html
+    - export DEPLOYPATH=/home/wwimpo/imporlan.cl
     - export BACKUPDIR=/home/wwimpo/backups
     - export TIMESTAMP=$(date +%Y-%m-%d_%H%M%S)
 

--- a/DEPLOY-SAFETY.md
+++ b/DEPLOY-SAFETY.md
@@ -1,20 +1,27 @@
 # Deploy Safety — Imporlan + Tourevo Shared Hosting
 
-## The problem we keep hitting
+## Status
+
+**Doc-root migration completed on 2026-05-17.** Imporlan now serves from
+its own physical directory `~/imporlan.cl/` (see "Long-term permanent fix"
+below — that section is now history, not a TODO). The mitigations
+documented below (sentinel, watchdog, guard) still apply as defence in
+depth.
+
+## Historical context — why this doc exists
 
 `imporlan.cl` and `tourevo.cl` live on the **same cPanel account**
-(`wwimpo@single-4020.banahosting.com`). Imporlan is configured as the
-**primary domain** of that account, so its doc-root is the bare
-`~/public_html/`. Tourevo is an addon/alias on the same account.
+(`wwimpo@single-4020.banahosting.com`). Until 2026-05-17, Imporlan was
+the **primary domain** of that account, so its doc-root was the bare
+`~/public_html/`. Tourevo was an addon/alias sharing the same physical
+directory tree.
 
-The two domains end up sharing the same physical directory tree on the
-server. Apache picks which content to serve via Host-aware rewrite rules
-in `.htaccess`, but at the filesystem level **both sites can write to
-the same path**.
-
-Concretely: a `cp -Rf` from a Tourevo build into `~/public_html/` will
-overwrite Imporlan's `index.html`, and vice versa. We've seen this in
-production multiple times (incidents on 2026-04-19 and 2026-05-11).
+That meant Apache picked which content to serve via Host-aware rewrite
+rules in `.htaccess`, but at the filesystem level **both sites could
+write to the same path**. A `cp -Rf` from a Tourevo build into
+`~/public_html/` would overwrite Imporlan's `index.html`, and vice versa.
+We hit this in production multiple times (incidents on 2026-04-19 and
+2026-05-11) which is what drove the migration.
 
 ## Short-term mitigations (this repo)
 
@@ -24,7 +31,7 @@ After every successful deploy, `auto-deploy.sh` and `deploy-prod.sh`
 write a sentinel marker:
 
 ```
-~/public_html/.imporlan_docroot
+~/imporlan.cl/.imporlan_docroot
 ```
 
 Before the next deploy, both scripts check that:
@@ -34,7 +41,7 @@ Before the next deploy, both scripts check that:
   (`imporlan` or `Importación de Lanchas`).
 
 If neither is true the deploy aborts with exit code 2 and takes a
-**defensive snapshot** of whatever was at `~/public_html/` into
+**defensive snapshot** of whatever was at `~/imporlan.cl/` into
 `~/backups/unknown_docroot_<timestamp>` so we can recover it if it
 turns out to be another site's content.
 
@@ -75,19 +82,21 @@ And after a successful deploy Tourevo should write its own sentinel:
 echo "Tourevo doc-root, last deploy: $(date)" > /home/wwimpo/tourevo/.tourevo_docroot
 ```
 
-## Long-term permanent fix (cPanel restructure)
+## Long-term permanent fix (cPanel restructure) — DONE 2026-05-17
 
-The short-term mitigations make accidental overwrites loud instead of
-silent, but the structural problem is the **shared doc-root**. The
-proper fix is to give each domain its own physical directory:
+The short-term mitigations made accidental overwrites loud instead of
+silent, but the structural problem was the **shared doc-root**. The
+proper fix was to give each domain its own physical directory:
 
 ```
-/home/wwimpo/imporlan.cl/        <- new Imporlan doc-root
-/home/wwimpo/tourevo.cl/         <- new Tourevo doc-root
-/home/wwimpo/public_html/        <- only a parking page (or empty)
+/home/wwimpo/imporlan.cl/        <- Imporlan doc-root (active)
+/home/wwimpo/tourevo.cl/         <- Tourevo doc-root
+/home/wwimpo/public_html/        <- now serves wwimpo-default.com (parking)
 ```
 
-### Steps (perform once, requires hosting admin access)
+The steps below are kept as a record of how the migration was performed.
+
+### Steps (performed once, required hosting admin access)
 
 1. **In cPanel: change Imporlan's primary doc-root.**
 
@@ -145,15 +154,15 @@ curl -fsSL https://www.imporlan.cl/ | grep -oE '<title>[^<]+</title>'
 # 2. Restore the home page from the latest main:
 TMP=~/imporlan-restore-$(date +%s)
 git clone --depth=1 https://github.com/jpchs1/Imporlan.git "$TMP"
-cp ~/public_html/index.html ~/public_html/index.html.foreign-backup-$(date +%s)
-cp -a "$TMP/index.html" ~/public_html/index.html
+cp ~/imporlan.cl/index.html ~/imporlan.cl/index.html.foreign-backup-$(date +%s)
+cp -a "$TMP/index.html" ~/imporlan.cl/index.html
 rm -rf "$TMP"
 
 # 3. Refresh the sentinel so the next auto-deploy won't trip the guard:
-cat > ~/public_html/.imporlan_docroot <<EOF
+cat > ~/imporlan.cl/.imporlan_docroot <<EOF
 Imporlan doc-root, restored manually $(date)
 EOF
-chmod 644 ~/public_html/.imporlan_docroot
+chmod 644 ~/imporlan.cl/.imporlan_docroot
 
 # 4. Cloudflare -> Purge Everything.
 # 5. Investigate auto-deploy.log + look at the .foreign-backup-* file to

--- a/api/cron/cotizador_publish.php
+++ b/api/cron/cotizador_publish.php
@@ -13,10 +13,10 @@
  * email goes out promptly even if the client doesn't actively check.
  *
  * cPanel cron entry (run hourly):
- *   0 * * * * /usr/bin/php /home/wwimpo/public_html/api/cron/cotizador_publish.php >/dev/null 2>&1
+ *   0 * * * * /usr/bin/php /home/wwimpo/imporlan.cl/api/cron/cotizador_publish.php >/dev/null 2>&1
  *
  * To trigger manually for testing:
- *   php /home/wwimpo/public_html/api/cron/cotizador_publish.php
+ *   php /home/wwimpo/imporlan.cl/api/cron/cotizador_publish.php
  *
  * Output goes to stdout when run from CLI, or is suppressed under HTTP unless
  * the CRON_DEBUG env var is set.

--- a/api/cron/security_scan.php
+++ b/api/cron/security_scan.php
@@ -6,7 +6,7 @@
  * Scans for suspicious files, unauthorized changes, and known malware patterns.
  *
  * Usage (cPanel cron, run daily):
- *   php /home/wwimpo/public_html/api/cron/security_scan.php
+ *   php /home/wwimpo/imporlan.cl/api/cron/security_scan.php
  *
  * Or via URL with token:
  *   GET /api/cron/security_scan.php?token=YOUR_DEPLOY_TOKEN
@@ -39,7 +39,7 @@ require_once dirname(__DIR__) . '/security_alerts.php';
 
 $alerts = new SecurityAlerts();
 $findings = [];
-$basePath = '/home/wwimpo/public_html';
+$basePath = '/home/wwimpo/imporlan.cl';
 
 // Adjust base path if not on production server
 if (!is_dir($basePath)) {

--- a/api/deploy.php
+++ b/api/deploy.php
@@ -33,8 +33,8 @@ define('REPO_URL', 'https://github.com/jpchs1/Imporlan.git');
 define('BRANCH', 'main');
 
 // Rutas
-define('PATH_TEST', '/home/wwimpo/public_html/test');
-define('PATH_PROD', '/home/wwimpo/public_html');
+define('PATH_TEST', '/home/wwimpo/imporlan.cl/test');
+define('PATH_PROD', '/home/wwimpo/imporlan.cl');
 
 // Archivos protegidos (no se sobrescriben)
 $protectedFiles = [

--- a/api/lscache-purge.php
+++ b/api/lscache-purge.php
@@ -33,7 +33,7 @@ header('X-LiteSpeed-Purge: *');
 
 // Also try to clear LiteSpeed cache directory if it exists
 $results = [];
-$publicPath = '/home/wwimpo/public_html';
+$publicPath = '/home/wwimpo/imporlan.cl';
 
 // Clear lscache directory
 $lscachePath = $publicPath . '/lscache';

--- a/api/marketplace_cron.php
+++ b/api/marketplace_cron.php
@@ -7,7 +7,7 @@
  *   2. Auto-expire listings past their expires_at date
  * 
  * Run via cPanel cron (once daily, e.g. 08:00 Chile time):
- *   php /home/wwimpo/public_html/api/marketplace_cron.php
+ *   php /home/wwimpo/imporlan.cl/api/marketplace_cron.php
  * 
  * Or via HTTP with secret key:
  *   GET /api/marketplace_cron.php?key=YOUR_CRON_KEY

--- a/auto-deploy.sh
+++ b/auto-deploy.sh
@@ -13,7 +13,7 @@ set -euo pipefail
 # ============================================
 
 REPO_DIR="/home/wwimpo/imporlan-staging"
-PUBLIC_HTML="/home/wwimpo/public_html"
+PUBLIC_HTML="/home/wwimpo/imporlan.cl"
 BACKUP_DIR="/home/wwimpo/backups"
 LOGFILE="/home/wwimpo/auto-deploy.log"
 LOCKFILE="/home/wwimpo/.deploy.lock"

--- a/deploy-guard.sh
+++ b/deploy-guard.sh
@@ -6,10 +6,12 @@
 #
 #  PURPOSE
 #  -------
-#  imporlan.cl and tourevo.cl share the same cPanel account
-#  (/home/wwimpo/public_html). Any naive `cp -Rf` from a Tourevo build
-#  into $PUBLIC_HTML will obliterate Imporlan content (this has happened).
-#  Conversely a Tourevo-deployed `index.html` will replace Imporlan's.
+#  imporlan.cl and tourevo.cl share the same cPanel account but now live
+#  in separate docroots (~/imporlan.cl/ and ~/tourevo.cl/ respectively).
+#  This guard remains as defence in depth: any naive `cp -Rf` aimed at
+#  the wrong path could still obliterate the other site's content.
+#  Pre-2026-05-17, both sites shared ~/public_html/, which is what
+#  motivated this script.
 #
 #  This script must be sourced (or called) by every deploy script before
 #  it writes a single byte into the target directory. It checks:
@@ -24,7 +26,7 @@
 #  ------------------------------
 #  Call directly:
 #    bash /path/to/deploy-guard.sh \
-#         --target /home/wwimpo/public_html \
+#         --target /home/wwimpo/imporlan.cl \
 #         --site imporlan \
 #         --marker 'imporlan|Importaci[oó]n de Lanchas' \
 #         --backup-dir /home/wwimpo/backups

--- a/deploy-prod.sh
+++ b/deploy-prod.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 STAGING_REPO="/home/wwimpo/imporlan-staging"
-PUBLIC_HTML="/home/wwimpo/public_html"
+PUBLIC_HTML="/home/wwimpo/imporlan.cl"
 BACKUP_DIR="/home/wwimpo/backups"
 TIMESTAMP=$(date +%Y-%m-%d_%H%M)
 SENTINEL="$PUBLIC_HTML/.imporlan_docroot"

--- a/deploy-test.sh
+++ b/deploy-test.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 STAGING_REPO="/home/wwimpo/imporlan-staging"
-PUBLIC_HTML="/home/wwimpo/public_html"
+PUBLIC_HTML="/home/wwimpo/imporlan.cl"
 BACKUP_DIR="/home/wwimpo/backups"
 TIMESTAMP=$(date +%Y-%m-%d_%H%M)
 
@@ -109,17 +109,17 @@ echo "[7/8] Validating deployment..."
 VALID=true
 
 if [ ! -f "$PUBLIC_HTML/panel-test/index.html" ]; then
-  echo "  ERROR: Missing /home/wwimpo/public_html/panel-test/index.html"
+  echo "  ERROR: Missing $PUBLIC_HTML/panel-test/index.html"
   VALID=false
 fi
 
 if [ ! -f "$PUBLIC_HTML/panel-test/admin/index.html" ]; then
-  echo "  ERROR: Missing /home/wwimpo/public_html/panel-test/admin/index.html"
+  echo "  ERROR: Missing $PUBLIC_HTML/panel-test/admin/index.html"
   VALID=false
 fi
 
 if [ ! -f "$PUBLIC_HTML/test/index.html" ]; then
-  echo "  ERROR: Missing /home/wwimpo/public_html/test/index.html"
+  echo "  ERROR: Missing $PUBLIC_HTML/test/index.html"
   VALID=false
 fi
 

--- a/docs/TRACKING.md
+++ b/docs/TRACKING.md
@@ -96,7 +96,7 @@ Authorization: Bearer {admin_token}
 
 Ejecuta diariamente a las 2 AM:
 ```
-0 2 * * * /usr/bin/php /home/wwimpo/public_html/api/cron/rotate_featured_vessels.php
+0 2 * * * /usr/bin/php /home/wwimpo/imporlan.cl/api/cron/rotate_featured_vessels.php
 ```
 
 Funciones:

--- a/imporlan-watchdog.sh
+++ b/imporlan-watchdog.sh
@@ -4,14 +4,14 @@
 # ============================================
 #  Runs every minute via cron. Detects if imporlan.cl is serving
 #  non-Imporlan content (typically: another site's deploy clobbered
-#  ~/public_html/index.html) and auto-restores it from the staging
+#  ~/imporlan.cl/index.html) and auto-restores it from the staging
 #  repo within ~60 seconds.
 #
 #  This is defence in depth -- the primary protection lives in
 #  auto-deploy.sh and deploy-guard.sh, which prevent Imporlan's own
 #  deploys from running on the wrong doc-root. The watchdog catches
 #  the case where ANOTHER site's deploy (Tourevo, etc.) writes into
-#  /public_html/ by mistake.
+#  ~/imporlan.cl/ by mistake.
 #
 #  INSTALL
 #    1. Place this file at /home/wwimpo/imporlan-watchdog.sh
@@ -30,7 +30,7 @@
 # ============================================
 set -uo pipefail
 
-PUBLIC_HTML="/home/wwimpo/public_html"
+PUBLIC_HTML="/home/wwimpo/imporlan.cl"
 STAGING="/home/wwimpo/imporlan-staging"
 LOG="/home/wwimpo/imporlan-watchdog.log"
 FLAG_DIR="/home/wwimpo"

--- a/test/api/admin_reset_password.php
+++ b/test/api/admin_reset_password.php
@@ -17,7 +17,7 @@ $tokenFile = $tokenDir . '/token.json';
 
 $cpanelConfigFile = '/home/wwimpo/credentials_config.php';
 // From test/api/ the production secret file lives at ../../api/.admin_password
-$rootDir = dirname(dirname(__DIR__)); // public_html root
+$rootDir = dirname(dirname(__DIR__)); // imporlan.cl docroot
 $persistentSecretFile = $rootDir . '/api/.admin_password';
 
 // Handle POST (password update)

--- a/test/api/cron/cotizador_publish.php
+++ b/test/api/cron/cotizador_publish.php
@@ -13,10 +13,10 @@
  * email goes out promptly even if the client doesn't actively check.
  *
  * cPanel cron entry (run hourly):
- *   0 * * * * /usr/bin/php /home/wwimpo/public_html/api/cron/cotizador_publish.php >/dev/null 2>&1
+ *   0 * * * * /usr/bin/php /home/wwimpo/imporlan.cl/api/cron/cotizador_publish.php >/dev/null 2>&1
  *
  * To trigger manually for testing:
- *   php /home/wwimpo/public_html/api/cron/cotizador_publish.php
+ *   php /home/wwimpo/imporlan.cl/api/cron/cotizador_publish.php
  *
  * Output goes to stdout when run from CLI, or is suppressed under HTTP unless
  * the CRON_DEBUG env var is set.

--- a/test/api/deploy.php
+++ b/test/api/deploy.php
@@ -33,8 +33,8 @@ define('REPO_URL', 'https://github.com/jpchs1/Imporlan.git');
 define('BRANCH', 'main');
 
 // Rutas
-define('PATH_TEST', '/home/wwimpo/public_html/test');
-define('PATH_PROD', '/home/wwimpo/public_html');
+define('PATH_TEST', '/home/wwimpo/imporlan.cl/test');
+define('PATH_PROD', '/home/wwimpo/imporlan.cl');
 
 // Archivos protegidos (no se sobrescriben)
 $protectedFiles = [


### PR DESCRIPTION
## Summary

Banahosting completed the primary-domain switch on 2026-05-17. Imporlan now lives in its own folder at `/home/wwimpo/imporlan.cl/` (re-added as addon domain post-switch). This PR updates every `PUBLIC_HTML` / `DEPLOYPATH` / hardcoded path that feeds deploys, watchdog, cron jobs, and cache purging so the new docroot is the single source of truth.

The site is already serving correctly from `/home/wwimpo/imporlan.cl/` — this PR aligns the repo so future deploys write to the right place.

### Functional code
- `auto-deploy.sh`, `deploy-prod.sh`, `deploy-test.sh`, `imporlan-watchdog.sh`: `PUBLIC_HTML` → `/home/wwimpo/imporlan.cl`
- `.cpanel.yml`: `DEPLOYPATH` → `/home/wwimpo/imporlan.cl`
- `api/deploy.php`, `test/api/deploy.php`: `PATH_TEST` + `PATH_PROD`
- `api/lscache-purge.php`, `api/cron/security_scan.php`: base path

### Comments / docs
- Cron docblocks (`api/cron/`, `api/marketplace_cron.php`, test mirrors)
- `docs/TRACKING.md`, `.agents/skills/deployment/SKILL.md`
- `DEPLOY-SAFETY.md`: mark long-term fix as DONE, update incident response
- `deploy-guard.sh`: header + example invocation

### Intentionally NOT changed
`migrate-imporlan-to-own-folder.sh` keeps `SRC=/home/wwimpo/public_html` — it's the one-shot staging tool that copies FROM the old location.

## Test plan
- [ ] Site loads at https://www.imporlan.cl
- [ ] After merge + `git pull origin main` on server, `grep ^PUBLIC_HTML imporlan-staging/auto-deploy.sh` shows `/home/wwimpo/imporlan.cl`
- [ ] Manual `deploy-prod.sh` writes to `/home/wwimpo/imporlan.cl/`, not `public_html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFknrJmwoMfC38TbjKb3KC)_