### PR TITLE
Orders: auto-scrape every link on order creation (and on recovery)

### DIFF
--- a/api/link_scraper.php
+++ b/api/link_scraper.php
@@ -34,19 +34,34 @@ switch ($action) {
 
 function fetchLinkMetadata() {
     $url = $_GET['url'] ?? '';
+    $result = scrapeLinkData($url);
+    if (isset($result['_http_code'])) {
+        http_response_code($result['_http_code']);
+        unset($result['_http_code']);
+    }
+    echo json_encode($result);
+}
 
+/**
+ * Reusable server-side scrape entry point.
+ *
+ * Returns the same array shape `fetchLinkMetadata()` echoes to clients, but
+ * without writing to stdout. Used by orders_api.php (createOrderFromQuotation)
+ * and migrations/recover_quotation_links.php so the customer's expediente
+ * arrives pre-populated with images and specs the moment the payment
+ * confirms, removing the need for the admin to click "re-scrape" per row.
+ *
+ * On invalid URL, returns ['error' => '...', '_http_code' => 400].
+ */
+function scrapeLinkData($url) {
     if (!$url || !filter_var($url, FILTER_VALIDATE_URL)) {
-        http_response_code(400);
-        echo json_encode(['error' => 'URL invalida']);
-        return;
+        return ['error' => 'URL invalida', '_http_code' => 400];
     }
 
     $allowedSchemes = ['http', 'https'];
     $parsedUrl = parse_url($url);
     if (!isset($parsedUrl['scheme']) || !in_array($parsedUrl['scheme'], $allowedSchemes)) {
-        http_response_code(400);
-        echo json_encode(['error' => 'Solo se permiten URLs HTTP/HTTPS']);
-        return;
+        return ['error' => 'Solo se permiten URLs HTTP/HTTPS', '_http_code' => 400];
     }
 
     $result = [
@@ -120,7 +135,7 @@ function fetchLinkMetadata() {
         }
     }
 
-    echo json_encode($result);
+    return $result;
 }
 
 function directFetch($url) {

--- a/api/migrations/recover_quotation_links.php
+++ b/api/migrations/recover_quotation_links.php
@@ -115,6 +115,17 @@ try {
     exit(1);
 }
 
+// Auto-scrape each URL using the same helper createOrderFromQuotation() now
+// uses, so a manually recovered expediente arrives with title/image/specs
+// already populated, just like the auto-created ones. Best-effort.
+echo "Running auto-scrape on " . count($links) . " link(s)... (this can take ~15-30s per link)\n";
+try {
+    autoScrapeAndUpdateOrderLinks($pdo, $orderId, $links);
+    echo "Auto-scrape finished. The expediente now has title/image/specs where the scraper could extract them.\n";
+} catch (Throwable $e) {
+    fwrite(STDERR, "WARNING: auto-scrape raised an error but the URLs were still saved. " . $e->getMessage() . "\n");
+}
+
 $purchasesFile = __DIR__ . '/../purchases.json';
 if (file_exists($purchasesFile)) {
     $raw = file_get_contents($purchasesFile);

--- a/api/orders_api.php
+++ b/api/orders_api.php
@@ -1727,9 +1727,84 @@ function createOrderFromQuotation($purchase, $storedLinks = []) {
             error_log("Failed to create quotation_ready notifications for order #{$orderNumber}: " . $e->getMessage());
         }
 
+        // Auto-scrape each URL via the existing link_scraper.php so the
+        // expediente arrives pre-populated with title, image, year/make/model,
+        // engine, location, hours and value_usa_usd. Best-effort: any scrape
+        // failure is logged but doesn't abort the order. Reuses the exact same
+        // logic the admin's "re-scrape" button (LinkRow.jsx) triggers when a
+        // URL is pasted into a row.
+        if (!empty($storedLinks)) {
+            try {
+                $urls = array_map(function ($l) {
+                    return is_array($l) ? ($l['url'] ?? $l['link'] ?? '') : (string) $l;
+                }, $storedLinks);
+                autoScrapeAndUpdateOrderLinks($pdo, $orderId, $urls);
+            } catch (\Throwable $e) {
+                error_log("auto-scrape failed for order #{$orderNumber}: " . $e->getMessage());
+            }
+        }
+
         return $orderId;
     } catch (PDOException $e) {
         error_log("Error creating order from quotation: " . $e->getMessage());
         return null;
+    }
+}
+
+/**
+ * Run the existing link_scraper.php server-side for every URL on the order,
+ * and UPDATE the matching order_links row with the resulting title, image,
+ * year/make/model, engine, location, hours and USA value.
+ *
+ * Best-effort: per-URL failures are caught and logged but don't abort the
+ * loop. The scraper itself has cURL timeouts (12s direct, up to 30s with
+ * Plan B), so the worst case for N links is roughly 30 * N seconds — for
+ * typical 1-5 link quotations this stays well within webhook windows.
+ *
+ * Mirrors the exact same call the admin React panel (LinkRow.jsx) makes
+ * when an admin pastes a URL into a row, so the auto-scrape on creation
+ * is functionally identical to a manual paste.
+ */
+function autoScrapeAndUpdateOrderLinks($pdo, $orderId, $urls) {
+    require_once __DIR__ . '/link_scraper.php';
+
+    foreach ($urls as $index => $url) {
+        $url = trim((string) $url);
+        if ($url === '' || !preg_match('/^https?:\/\//i', $url)) continue;
+
+        try {
+            $data = scrapeLinkData($url);
+            if (!is_array($data) || !empty($data['error'])) continue;
+
+            // Build column list dynamically — only update fields the scraper
+            // actually returned non-empty so we never overwrite a value with
+            // NULL when the scraper couldn't extract that piece.
+            $map = [
+                'title'         => $data['title']         ?? null,
+                'image_url'     => $data['image_url']     ?? null,
+                'location'      => $data['location']      ?? null,
+                'hours'         => $data['hours']         ?? null,
+                'engine'        => $data['engine']        ?? null,
+                'make'          => $data['make']          ?? null,
+                'model'         => $data['model']         ?? null,
+                'year'          => isset($data['year']) ? intval($data['year']) : null,
+                'value_usa_usd' => isset($data['value_usa_usd']) ? floatval($data['value_usa_usd']) : null,
+            ];
+            $sets = [];
+            $params = [];
+            foreach ($map as $col => $val) {
+                if ($val === null || $val === '' || $val === 0 || $val === 0.0) continue;
+                $sets[] = "{$col} = ?";
+                $params[] = $val;
+            }
+            if (empty($sets)) continue;
+
+            $params[] = $orderId;
+            $params[] = $index + 1;
+            $sql = "UPDATE order_links SET " . implode(', ', $sets) . " WHERE order_id = ? AND row_index = ?";
+            $pdo->prepare($sql)->execute($params);
+        } catch (\Throwable $e) {
+            error_log("autoScrapeAndUpdateOrderLinks: failed for url={$url}: " . $e->getMessage());
+        }
     }
 }


### PR DESCRIPTION
## Why

After PR #543/#544 the expediente arrives populated with the URLs, but the rest of the fields (title, image, year/make/model, engine, location, hours, USA value) stay empty until the admin opens each row and pastes the URL again to trigger the scraper. The customer therefore sees their links cargados but no thumbnails, model names or specs — which feels half-finished.

The admin already has a working scraper (`api/link_scraper.php`, used today by `admin-react/src/admin/components/LinkRow.jsx` when an admin pastes a URL). It was never invoked server-side when the order itself was created.

## What changes

- **`api/link_scraper.php`** — refactor `fetchLinkMetadata()` to call a new reusable `scrapeLinkData($url)`. The HTTP behaviour is unchanged.
- **`api/orders_api.php`** — new helper `autoScrapeAndUpdateOrderLinks($pdo, $orderId, $urls)`. Called from `createOrderFromQuotation()` right after the order_links rows are inserted and the notifications are fanned out. Best-effort, per-URL failures are caught and logged but don't abort the order.
- **`api/migrations/recover_quotation_links.php`** — same auto-scrape after the manual recovery, so backfilled orders (like jaze50@gmail.com's #IMP-00027 from the 2026-05-18 incident) get the same pre-population.

The scraping path is identical to the one `LinkRow.jsx` triggers when an admin pastes a URL into a row, so the auto behaviour matches the manual-paste behaviour 1:1.

## Timing

`scrapeLinkData()` uses the existing cURL fetch with 12s direct timeout and up to 30s with Plan B fallback. For typical 1-5 link quotations this stays well within Mercado Pago / WebPay / PayPal webhook windows. For a 10-link quotation the worst case can be longer; in practice most links return in 2-5s.

## Test plan

- [ ] Pay a Cotizacion por Links via any gateway with a yachtworld/boattrader link → expediente arrives with the photo, year, make, model, value and location already filled in.
- [ ] Backfill an existing empty order via `php migrations/recover_quotation_links.php <id> '[...]'` → same result.
- [ ] Confirm the admin paste-URL flow (LinkRow.jsx) still works (no regression in the scraper signature).

https://claude.ai/code/session_01P4djuHcbMmeiN9KtcYXAWy

---
_Generated by [Claude Code](https://claude.ai/code/session_01P4djuHcbMmeiN9KtcYXAWy)_