### PR TITLE
Link scraper: skip HTTP entry block when file is included server-side

### DIFF
--- a/api/link_scraper.php
+++ b/api/link_scraper.php
@@ -10,26 +10,32 @@
 
 require_once __DIR__ . '/auth_helper.php';
 
-header('Access-Control-Allow-Origin: *');
-header('Access-Control-Allow-Methods: GET, OPTIONS');
-header('Access-Control-Allow-Headers: Content-Type, Authorization');
-header('Content-Type: application/json');
+// The block below is the HTTP entry point. Skip it when this file is being
+// included by another script (e.g. orders_api.php's autoScrapeAndUpdateOrderLinks
+// or migrations/recover_quotation_links.php) so we just load the function
+// definitions without echoing 'Accion no valida' for the empty $_GET.
+if (basename($_SERVER['SCRIPT_FILENAME']) === basename(__FILE__)) {
+    header('Access-Control-Allow-Origin: *');
+    header('Access-Control-Allow-Methods: GET, OPTIONS');
+    header('Access-Control-Allow-Headers: Content-Type, Authorization');
+    header('Content-Type: application/json');
 
-if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
-    http_response_code(200);
-    exit();
-}
+    if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
+        http_response_code(200);
+        exit();
+    }
 
-$action = $_GET['action'] ?? '';
+    $action = $_GET['action'] ?? '';
 
-switch ($action) {
-    case 'fetch':
-        requireAdminAuthShared();
-        fetchLinkMetadata();
-        break;
-    default:
-        http_response_code(400);
-        echo json_encode(['error' => 'Accion no valida']);
+    switch ($action) {
+        case 'fetch':
+            requireAdminAuthShared();
+            fetchLinkMetadata();
+            break;
+        default:
+            http_response_code(400);
+            echo json_encode(['error' => 'Accion no valida']);
+    }
 }
 
 function fetchLinkMetadata() {


### PR DESCRIPTION
## Why

After #545 was deployed, the new `autoScrapeAndUpdateOrderLinks()` helper invoked from `createOrderFromQuotation()` and from `migrations/recover_quotation_links.php` triggered the HTTP entry point of `api/link_scraper.php`:

```
$ php -r 'require_once "orders_api.php"; autoScrapeAndUpdateOrderLinks(...)'
{"error":"Accion no valida"}
```

`link_scraper.php` runs a top-level `switch ($_GET['action'])` immediately when the file is included. With an empty `$_GET`, it falls through to the default case and echoes the error.

## Fix

Wrap the entry-point block in the same `basename($_SERVER['SCRIPT_FILENAME']) === basename(__FILE__)` guard `notifications_api.php` already uses. The HTTP endpoint behaviour is unchanged (the script is still the SCRIPT_FILENAME when hit via a browser). The function definitions just load cleanly when the file is `require_once`'d from another script.

## Test plan

- [ ] On the server, re-run the jaze50 scrape (`php -r 'require_once "orders_api.php"; ...'`) — output should be clean, no rogue JSON.
- [ ] Confirm `GET /api/link_scraper.php?action=fetch&url=...` still works from the admin React panel (LinkRow.jsx paste-URL flow).

https://claude.ai/code/session_01P4djuHcbMmeiN9KtcYXAWy

---
_Generated by [Claude Code](https://claude.ai/code/session_01P4djuHcbMmeiN9KtcYXAWy)_