### PR TITLE
fix(orders): aceptar order_id en admin_send_client_update

### DIFF
--- a/api/orders_api.php
+++ b/api/orders_api.php
@@ -1016,7 +1016,7 @@ function adminDeleteOrder() {
 
 function adminSendClientUpdate() {
     $input = json_decode(file_get_contents('php://input'), true);
-    $orderId = intval($input['id'] ?? 0);
+    $orderId = intval($input['order_id'] ?? $input['id'] ?? 0);
 
     if (!$orderId) {
         http_response_code(400);


### PR DESCRIPTION
## Problema

El botón **"Actualizar Cliente"** en el panel admin (ej. expediente IMP-00028) devolvía el error *"Se requiere id del expediente"*.

## Causa

El frontend (`admin-react/src/admin/api.js:82`) y el bundle desplegado llaman al endpoint `admin_send_client_update` enviando el campo `order_id`, pero el backend (`api/orders_api.php`) leía únicamente `$input['id']`. Al no encontrarlo, `$orderId` quedaba en `0` y el handler abortaba con el error.

## Solución

`adminSendClientUpdate()` ahora acepta ambas claves:

```php
$orderId = intval($input['order_id'] ?? $input['id'] ?? 0);
```

Resuelto en el backend a propósito: el bundle ya desplegado también envía `order_id`, así que el fix corrige producción sin necesidad de recompilar el frontend.

## Test plan
- [ ] Abrir un expediente en el panel admin y pulsar "Actualizar Cliente"
- [ ] Verificar que se envía el email de actualización al cliente y desaparece el error

https://claude.ai/code/session_01JzKRCp9PTq2XvDCduAatQz

---
_Generated by [Claude Code](https://claude.ai/code/session_01JzKRCp9PTq2XvDCduAatQz)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jpchs1/imporlan/pull/548" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->