### PR TITLE
feat(seo): enrich Product schema + add AggregateRating (Phase 4/4)

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,7 +130,15 @@
         "https://www.youtube.com/@imporlan",
         "https://www.instagram.com/imporlan.cl/",
         "https://www.facebook.com/imporlan"
-      ]
+      ],
+      "aggregateRating": {
+        "@type": "AggregateRating",
+        "ratingValue": "4.9",
+        "reviewCount": "4",
+        "bestRating": "5",
+        "worstRating": "1",
+        "url": "https://www.imporlan.cl/casos-de-importacion/"
+      }
     }
     </script>
     <script type="application/ld+json">

--- a/marketplace/embarcacion.php
+++ b/marketplace/embarcacion.php
@@ -136,7 +136,22 @@ $jsVersion = '183';
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="<?php echo $basePath; ?>/assets/marketplace-public.css?v=<?php echo $cssVersion; ?>">
 
-<?php if ($listingId > 0 && isset($listing) && $listing): ?>
+<?php if ($listingId > 0 && isset($listing) && $listing):
+  // Build additionalProperty array from listing specs (eslora, tipo, condicion)
+  $additionalProperties = [];
+  if (!empty($listing['eslora'])) {
+    $additionalProperties[] = ['@type' => 'PropertyValue', 'name' => 'Eslora', 'value' => $listing['eslora']];
+  }
+  if (!empty($listing['tipo'])) {
+    $additionalProperties[] = ['@type' => 'PropertyValue', 'name' => 'Tipo de embarcación', 'value' => $listing['tipo']];
+  }
+  if (!empty($listing['condicion'])) {
+    $additionalProperties[] = ['@type' => 'PropertyValue', 'name' => 'Condición', 'value' => $listing['condicion']];
+  }
+  if (!empty($listing['ubicacion'])) {
+    $additionalProperties[] = ['@type' => 'PropertyValue', 'name' => 'Ubicación', 'value' => $listing['ubicacion']];
+  }
+?>
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -145,16 +160,28 @@ $jsVersion = '183';
     "description": <?php echo json_encode(mb_substr($listing['descripcion'] ?: $ogDescription, 0, 300), JSON_UNESCAPED_UNICODE); ?>,
     "image": <?php echo json_encode($ogImage, JSON_UNESCAPED_UNICODE); ?>,
     "url": <?php echo json_encode($canonicalUrl, JSON_UNESCAPED_UNICODE); ?>,
+    "sku": <?php echo json_encode('IMP-' . $listingId); ?>,
+    "category": <?php echo json_encode($listing['tipo'] ?: 'Embarcación'); ?>,
     "brand": {
       "@type": "Organization",
       "name": "Imporlan"
-    },
+    }<?php if (!empty($listing['ano'])): ?>,
+    "productionDate": <?php echo json_encode(strval($listing['ano'])); ?>,
+    "model": <?php echo json_encode(trim(($listing['nombre'] ?: '') . ' ' . $listing['ano'])); ?><?php endif; ?><?php if (!empty($additionalProperties)): ?>,
+    "additionalProperty": <?php echo json_encode($additionalProperties, JSON_UNESCAPED_UNICODE); ?><?php endif; ?>,
     "offers": {
       "@type": "Offer",
       "price": <?php echo json_encode(strval(floatval($listing['precio']))); ?>,
       "priceCurrency": <?php echo json_encode($listing['moneda'] ?: 'USD'); ?>,
       "availability": "https://schema.org/InStock",
-      "itemCondition": <?php echo json_encode($listing['estado'] === 'Nueva' ? 'https://schema.org/NewCondition' : 'https://schema.org/UsedCondition'); ?>
+      "itemCondition": <?php echo json_encode($listing['estado'] === 'Nueva' ? 'https://schema.org/NewCondition' : 'https://schema.org/UsedCondition'); ?>,
+      "url": <?php echo json_encode($canonicalUrl, JSON_UNESCAPED_UNICODE); ?>,
+      "seller": {
+        "@type": "Organization",
+        "name": "Imporlan",
+        "url": "https://www.imporlan.cl"
+      }<?php if (!empty($listing['ubicacion'])): ?>,
+      "areaServed": <?php echo json_encode($listing['ubicacion'], JSON_UNESCAPED_UNICODE); ?><?php endif; ?>
     }
   }
   </script>


### PR DESCRIPTION
## Summary (Phase 4 of 4 — final del roadmap)

Cierre del proyecto SEO/AI al 100%. Este PR enriquece el schema `Product` de cada listing individual del marketplace y añade `AggregateRating` al `BoatDealer` del home, replicando las 4 reviews/4.9 del Phase 3 para que Google las "fusione por @id" entre las dos páginas.

## Cambios

### `marketplace/embarcacion.php` — Product schema enriquecido

El Product ya existía pero era básico (name, description, image, brand, offers). Ahora añade:

- **`sku`**: `"IMP-{listingId}"` — identificador único persistente
- **`category`**: del campo `tipo` del listing (Lancha / Velero / Moto agua)
- **`productionDate` + `model`**: del campo `ano` cuando esté presente
- **`additionalProperty[]`**: eslora, tipo, condición, ubicación como `PropertyValue` (Google entiende esto como specs comparables → activa filtros y rich cards)
- **`offers.seller`**: Organization Imporlan (cierra el ciclo de garantía/marca)
- **`offers.url`**: canonical de la oferta
- **`offers.areaServed`**: ubicación geográfica del listing

### `index.html` — BoatDealer con AggregateRating

- `ratingValue` 4.9 / 5
- `reviewCount` 4 (consistente con el Service del Phase 3)
- `url` apunta a `/casos-de-importacion/` como evidencia
- Google merge-by-`@id` integra esto con el Service de casos → muestra estrellas en SERP del home y en cualquier mención de la marca

## Beneficios esperados

- **Listings individuales** (`/marketplace/embarcacion.php?id=N`) ahora son elegibles para Google Shopping y Bing Shopping
- **Home muestra estrellas** en SERP cuando alguien busca "Imporlan"
- **AggregateRating + Product + Review forma el "trifecta" E-E-A-T** que premia Google y citan las IAs

## Cierre del roadmap SEO 100%

- [x] Phase 1 (#552): pillar `/importacion-de-lanchas/`
- [x] Phase 2 (#553): calculadora interactiva con `SoftwareApplication`
- [x] Phase 3 (#554): Reviews + AggregateRating en `/casos-de-importacion/`
- [x] **Phase 4** (este): Product enriquecido + AggregateRating home

## Test plan
- [ ] CI lint checks pasan (PHP syntax especialmente — ya validado local con `php -l`)
- [ ] Post-merge: cargar cualquier listing con `?id=N` y verificar 1 schema Product con los nuevos campos
- [ ] Validar con `https://search.google.com/test/rich-results`
- [ ] Buscar "Imporlan" en Google en 1-2 semanas → ver si aparecen estrellas en el panel lateral

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFknrJmwoMfC38TbjKb3KC)_