### PR TITLE
fix(orders): garantizar links + email admin en Cotización por Links

### DIFF
--- a/api/email_service.php
+++ b/api/email_service.php
@@ -431,7 +431,79 @@ BASE64;
 
         return ['success' => $anySuccess, 'results' => $results];
     }
-    
+
+    /**
+     * Red de seguridad: email al admin cuando se crea un expediente de
+     * "Cotizacion por Links". Lo envia createOrderFromQuotation siempre que
+     * se crea un expediente nuevo, asegurando que el admin reciba al menos
+     * UN email focalizado con el numero de expediente y los links del
+     * cliente (o un aviso si los links no llegaron), independiente del path
+     * de pago. Complementa (no reemplaza) los emails de sendQuotationFormEmail.
+     */
+    public function sendNewExpedienteAdminEmail($orderNumber, $customerName, $customerEmail, $boatLinks = []) {
+        if (empty($this->adminEmails)) {
+            return ['success' => false, 'error' => 'No admin recipients configured'];
+        }
+
+        $items = [];
+        if (!empty($boatLinks) && is_array($boatLinks)) {
+            foreach ($boatLinks as $link) {
+                $url = is_array($link) ? ($link['url'] ?? $link['link'] ?? '') : (string) $link;
+                $url = trim($url);
+                if ($url === '') continue;
+                $safe = htmlspecialchars($url, ENT_QUOTES, 'UTF-8');
+                $items[] = '<li style="margin:6px 0;"><a href="' . $safe . '" style="color:#0891b2;word-break:break-all;">' . $safe . '</a></li>';
+            }
+        }
+
+        if (!empty($items)) {
+            $linksHtml = '<p style="margin:18px 0 6px;font-weight:600;color:#0f172a;">Links a cotizar (' . count($items) . '):</p>'
+                       . '<ol style="margin:0;padding-left:20px;">' . implode('', $items) . '</ol>';
+        } else {
+            $linksHtml = '<div style="margin:18px 0;padding:14px 16px;background:#fef3c7;border-left:4px solid #d97706;border-radius:6px;">'
+                       . '<strong style="color:#92400e;">Atencion:</strong> '
+                       . '<span style="color:#92400e;">No se recibieron links del cliente en este expediente. '
+                       . 'Revisa <code>api/quotation_requests.json</code> y <code>api/purchases.json</code> en el servidor '
+                       . 'para localizarlos manualmente.</span>'
+                       . '</div>';
+        }
+
+        $safeName  = htmlspecialchars($customerName ?: 'Cliente', ENT_QUOTES, 'UTF-8');
+        $safeEmail = htmlspecialchars($customerEmail ?: '(sin email)', ENT_QUOTES, 'UTF-8');
+        $safeOrder = htmlspecialchars($orderNumber ?: '', ENT_QUOTES, 'UTF-8');
+        $panelUrl  = 'https://www.imporlan.cl/panel/admin/#/orders';
+
+        $content = '
+            <h2 style="margin:0 0 6px;color:#0f172a;font-size:20px;">Nuevo expediente: ' . $safeOrder . '</h2>
+            <p style="margin:0 0 18px;color:#64748b;font-size:14px;">Cotizacion por Links - pendiente de revision</p>
+            <table style="border-collapse:collapse;width:100%;margin-bottom:6px;">
+                <tr><td style="padding:6px 0;color:#64748b;width:120px;">Cliente:</td><td style="padding:6px 0;color:#0f172a;font-weight:600;">' . $safeName . '</td></tr>
+                <tr><td style="padding:6px 0;color:#64748b;">Email:</td><td style="padding:6px 0;color:#0f172a;">' . $safeEmail . '</td></tr>
+                <tr><td style="padding:6px 0;color:#64748b;">Servicio:</td><td style="padding:6px 0;color:#0f172a;">Cotizacion por Links</td></tr>
+            </table>
+            ' . $linksHtml . '
+            <p style="margin:28px 0 0;">
+                <a href="' . $panelUrl . '" style="display:inline-block;background:#0891b2;color:#fff;padding:11px 22px;border-radius:8px;text-decoration:none;font-weight:600;">Abrir en el panel admin</a>
+            </p>';
+
+        $html = $this->getBaseTemplate($content, 'Nuevo expediente ' . $safeOrder . ' - Imporlan');
+        $subject = 'Nuevo expediente ' . $safeOrder . ' - Cotizacion por Links (' . ($customerEmail ?: 'sin email') . ')';
+
+        $anySuccess = false;
+        $results = [];
+        foreach ($this->adminEmails as $adminEmail) {
+            $r = $this->sendEmail($adminEmail, $subject, $html, 'admin_new_expediente', [
+                'order_number'   => $orderNumber,
+                'customer_email' => $customerEmail,
+                'customer_name'  => $customerName,
+                'links_count'    => count($items),
+            ]);
+            $results[] = $r;
+            if (!empty($r['success'])) $anySuccess = true;
+        }
+        return ['success' => $anySuccess, 'results' => $results];
+    }
+
     /**
      * Send email notification to user when they receive a chat reply
      */

--- a/api/orders_api.php
+++ b/api/orders_api.php
@@ -1625,8 +1625,34 @@ function createOrderFromQuotation($purchase, $storedLinks = []) {
         return null;
     }
 
+    // Defensa en profundidad: si el caller no nos paso links pero el cliente
+    // envio antes el formulario, los recuperamos de quotation_requests.json.
+    // Esto evita expedientes con 10 filas vacias cuando el path de pago
+    // no propago boat_links correctamente.
+    $customerEmailForLookup = $purchase['user_email'] ?? $purchase['customer_email'] ?? '';
+    if (empty($storedLinks) && $customerEmailForLookup) {
+        try {
+            require_once __DIR__ . '/email_service.php';
+            $svcLookup = new EmailService();
+            $recovered = $svcLookup->getStoredQuotationLinks($customerEmailForLookup);
+            if (!empty($recovered)) {
+                $storedLinks = $recovered;
+                error_log("createOrderFromQuotation: recovered " . count($recovered) . " link(s) from quotation_requests.json for {$customerEmailForLookup}");
+            }
+        } catch (\Throwable $e) {
+            error_log("createOrderFromQuotation: fallback lookup error: " . $e->getMessage());
+        }
+    }
+    if (empty($storedLinks)) {
+        error_log("createOrderFromQuotation: WARNING - no links found for '{$customerEmailForLookup}' (purchase=" . ($purchase['id'] ?? 'n/a') . "). El expediente se creara con filas vacias.");
+    }
+
     try {
         $orderNumber = generateOrderNumber($pdo);
+
+        // empty() trata "" como faltante: si plan_name viene como string vacio,
+        // usamos el default. El "??" solo cae al default cuando es null.
+        $planName = !empty($purchase['plan_name']) ? $purchase['plan_name'] : 'Cotizacion por Links';
 
         $stmt = $pdo->prepare("
             INSERT INTO orders (order_number, customer_id, customer_email, customer_name, customer_phone,
@@ -1639,7 +1665,7 @@ function createOrderFromQuotation($purchase, $storedLinks = []) {
             $purchase['user_email'] ?? $purchase['customer_email'] ?? '',
             $purchase['customer_name'] ?? explode('@', $purchase['user_email'] ?? '')[0],
             $purchase['customer_phone'] ?? null,
-            $purchase['plan_name'] ?? 'Cotizacion por Links',
+            $planName,
             $purchase['description'] ?? '',
             $purchase['id'] ?? $purchase['purchase_id'] ?? null
         ]);
@@ -1725,6 +1751,25 @@ function createOrderFromQuotation($purchase, $storedLinks = []) {
             }
         } catch (\Throwable $e) {
             error_log("Failed to create quotation_ready notifications for order #{$orderNumber}: " . $e->getMessage());
+        }
+
+        // Red de seguridad: enviar email al admin con el numero de expediente
+        // y los links del cliente. Garantiza que el admin siempre se entera de
+        // un nuevo expediente con links (o de uno que llego sin links),
+        // independiente de que path de pago lo creo.
+        try {
+            require_once __DIR__ . '/email_service.php';
+            $svcExp = new EmailService();
+            if (method_exists($svcExp, 'sendNewExpedienteAdminEmail')) {
+                $svcExp->sendNewExpedienteAdminEmail(
+                    $orderNumber,
+                    $purchase['customer_name'] ?? '',
+                    $customerEmail ?? $customerEmailForLookup ?? '',
+                    $storedLinks
+                );
+            }
+        } catch (\Throwable $e) {
+            error_log("Failed to send admin new-expediente email for #{$orderNumber}: " . $e->getMessage());
         }
 
         // Auto-scrape each URL via the existing link_scraper.php so the


### PR DESCRIPTION
## Problema

El expediente **IMP-00029** (valvarez@codam.cl) se creó con 10 filas vacías y el admin no recibió email con el link. El campo Plan apareció como "-".

## Causa raíz

Tres puntos débiles en el flujo:

1. **`createOrderFromQuotation`** confiaba 100% en que el caller le pasara `$storedLinks`. Si el path de pago (webpay/paypal/mercadopago/`addPurchase`) perdía `boat_links` en el camino, llegaba vacío y el expediente nacía con 10 filas en blanco.
2. **`plan_name = ""`** (string vacío) no caía al default `"Cotizacion por Links"` — el `??` solo lo hace con `null`. Por eso el listado mostraba "-".
3. **No existía un email admin focalizado** al crear el expediente. Solo se enviaba la campana (bell) interna. Si `sendQuotationFormEmail` (que viene del path de pago) no se disparaba o llegaba sin links, el admin nunca se enteraba.

## Solución (defensa en profundidad)

**`api/orders_api.php` → `createOrderFromQuotation`:**
- Fallback automático: si `$storedLinks` viene vacío, busca en `quotation_requests.json` por email del cliente.
- `plan_name` vacío ahora cae al default correctamente.
- Log de WARNING claro cuando no se encuentran links en ninguna fuente — facilita diagnóstico futuro.
- Después de las notificaciones de campana, dispara el nuevo email admin.

**`api/email_service.php` → nuevo método público `sendNewExpedienteAdminEmail(...)`:**
- Email enviado a todos los `adminEmails` cada vez que se crea un expediente de Cotización por Links.
- Asunto: `Nuevo expediente IMP-XXXXX - Cotizacion por Links (email cliente)`.
- Cuerpo: cliente, email, lista numerada de links a cotizar y botón al panel admin.
- Si los links faltan, muestra un aviso destacado en amarillo apuntando dónde buscarlos en el servidor.
- Es complementario a `sendQuotationFormEmail` (no lo reemplaza).

## Pendiente
- Localizar el link real de valvarez en `purchases.json` (se está revisando) y agregarlo manualmente al expediente IMP-00029. El bug que dejó la URL "huérfana" en `addPurchase` (campo `url` vs `links`) se ajusta en un commit siguiente una vez confirmado.

## Test plan
- [ ] Crear un nuevo expediente de Cotización por Links → llega email admin con asunto "Nuevo expediente IMP-XXXXX..." e incluye los links
- [ ] Probar caso degradado (sin links): el email llega con aviso amarillo destacado, no falla silenciosamente
- [ ] Verificar que el listado de expedientes muestra "Cotizacion por Links" en lugar de "-" en la columna Plan para nuevos expedientes

https://claude.ai/code/session_01JzKRCp9PTq2XvDCduAatQz

---
_Generated by [Claude Code](https://claude.ai/code/session_01JzKRCp9PTq2XvDCduAatQz)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jpchs1/imporlan/pull/556" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->