### PR TITLE
feat(legal): páginas reales de Términos y Condiciones y Política de Privacidad

### DIFF
--- a/.cpanel.yml
+++ b/.cpanel.yml
@@ -76,6 +76,10 @@ deployment:
     - /bin/cp -Rf preguntas-frecuentes-embarcaciones-usadas $DEPLOYPATH/
     - /bin/cp -Rf tipos-de-lanchas-segun-uso $DEPLOYPATH/
 
+    # --- Deploy legal pages ---
+    - /bin/cp -Rf terminos-y-condiciones $DEPLOYPATH/
+    - /bin/cp -Rf politica-de-privacidad $DEPLOYPATH/
+
     # --- Post-deploy: restore server-only files ---
     - /bin/test -f $BACKUPDIR/pre_deploy_$TIMESTAMP/db_config.php && /bin/cp $BACKUPDIR/pre_deploy_$TIMESTAMP/db_config.php $DEPLOYPATH/api/db_config.php || true
     - /bin/test -d $BACKUPDIR/pre_deploy_$TIMESTAMP/marketplace_photos && /bin/cp -a $BACKUPDIR/pre_deploy_$TIMESTAMP/marketplace_photos $DEPLOYPATH/api/marketplace_photos || true

--- a/deploy-prod.sh
+++ b/deploy-prod.sh
@@ -192,6 +192,8 @@ SEO_PAGES=(
   "logistica-maritima-importacion"
   "preguntas-frecuentes-embarcaciones-usadas"
   "casos-de-importacion"
+  "terminos-y-condiciones"
+  "politica-de-privacidad"
 )
 for PAGE in "${SEO_PAGES[@]}"; do
   if [ -d "$STAGING_REPO/$PAGE" ]; then

--- a/politica-de-privacidad/index.html
+++ b/politica-de-privacidad/index.html
@@ -1,0 +1,275 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Política de Privacidad | Imporlan</title>
+    <meta name="description" content="Política de Privacidad de Imporlan: qué datos recopilamos, con qué finalidad, cómo los protegemos y cómo ejercer tus derechos conforme a la Ley 19.628 de Chile.">
+    <meta name="robots" content="index, follow">
+    <meta name="author" content="Imporlan">
+    <link rel="canonical" href="https://www.imporlan.cl/politica-de-privacidad/">
+    <link rel="alternate" hreflang="es" href="https://www.imporlan.cl/politica-de-privacidad/">
+    <link rel="alternate" hreflang="x-default" href="https://www.imporlan.cl/politica-de-privacidad/">
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="Política de Privacidad | Imporlan">
+    <meta property="og:description" content="Cómo Imporlan recopila, usa y protege tus datos personales.">
+    <meta property="og:url" content="https://www.imporlan.cl/politica-de-privacidad/">
+    <meta property="og:site_name" content="Imporlan">
+    <meta property="og:locale" content="es_CL">
+    <meta property="og:image" content="https://www.imporlan.cl/images/imporlan-og.jpg">
+    <link rel="icon" type="image/svg+xml" href="/images/imporlan-favicon.svg">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../assets/seo/seo-pages.css">
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "WebPage",
+        "name": "Política de Privacidad | Imporlan",
+        "description": "Política de Privacidad de Imporlan conforme a la Ley 19.628 de Chile.",
+        "url": "https://www.imporlan.cl/politica-de-privacidad/",
+        "datePublished": "2026-06-19",
+        "dateModified": "2026-06-19",
+        "inLanguage": "es-CL",
+        "publisher": { "@type": "Organization", "name": "Imporlan", "url": "https://www.imporlan.cl" }
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+            {"@type": "ListItem", "position": 1, "name": "Inicio", "item": "https://www.imporlan.cl/"},
+            {"@type": "ListItem", "position": 2, "name": "Política de Privacidad", "item": "https://www.imporlan.cl/politica-de-privacidad/"}
+        ]
+    }
+    </script>
+    <style>
+      .legal-wrap { background: #f1f5f9; padding: 40px 0 64px; }
+      .legal-card { max-width: 880px; margin: 0 auto; background: #fff; border: 1px solid #e2e8f0; border-radius: 16px; padding: 40px 44px; box-shadow: 0 18px 40px -24px rgba(15,23,42,.25); }
+      .legal-card .legal-updated { display: inline-block; font-size: 13px; font-weight: 600; color: #0891b2; background: #ecfeff; border: 1px solid #a5f3fc; border-radius: 9999px; padding: 5px 14px; margin-bottom: 22px; }
+      .legal-card h2 { font-size: 1.35rem; color: #0f172a; margin: 34px 0 12px; font-weight: 700; line-height: 1.3; }
+      .legal-card h2:first-of-type { margin-top: 6px; }
+      .legal-card h3 { font-size: 1.05rem; color: #1e293b; margin: 20px 0 8px; font-weight: 600; }
+      .legal-card p, .legal-card li { color: #334155; font-size: 15.5px; line-height: 1.75; }
+      .legal-card p { margin: 0 0 14px; }
+      .legal-card ul { margin: 0 0 16px; padding-left: 20px; }
+      .legal-card li { margin-bottom: 8px; }
+      .legal-card strong { color: #0f172a; }
+      .legal-card a { color: #0891b2; text-decoration: underline; }
+      .legal-id { background: #f8fafc; border: 1px solid #e2e8f0; border-left: 4px solid #06b6d4; border-radius: 10px; padding: 16px 20px; margin: 8px 0 18px; }
+      .legal-id p { margin: 4px 0; font-size: 14.5px; }
+      .legal-note { background: #fffbeb; border: 1px solid #fde68a; border-radius: 10px; padding: 14px 18px; margin: 24px 0 0; font-size: 13.5px; color: #92400e; }
+      .legal-toc { background:#f8fafc; border:1px solid #e2e8f0; border-radius:10px; padding:16px 20px; margin-bottom: 8px; }
+      .legal-toc strong { display:block; margin-bottom:8px; color:#0f172a; }
+      .legal-toc ol { margin:0; padding-left:20px; }
+      .legal-toc a { color:#0891b2; }
+      @media (max-width: 640px) { .legal-card { padding: 28px 20px; border-radius: 12px; } .legal-card h2 { font-size: 1.2rem; } }
+    </style>
+</head>
+<body>
+    <!-- Header -->
+    <header class="seo-header">
+        <div class="container">
+            <a href="/" class="seo-logo">
+                <div class="seo-logo-icon">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M2 21c.6.5 1.2 1 2.5 1 2.5 0 2.5-2 5-2 1.3 0 1.9.5 2.5 1 .6.5 1.2 1 2.5 1 2.5 0 2.5-2 5-2 1.3 0 1.9.5 2.5 1"/>
+                        <path d="M19.38 20A11.6 11.6 0 0 0 21 14l-9-4-9 4c0 2.9.94 5.34 2.81 7.76"/>
+                        <path d="M19 13V7a2 2 0 0 0-2-2H7a2 2 0 0 0-2 2v6"/>
+                        <path d="M12 10v4"/>
+                    </svg>
+                </div>
+                <div class="seo-logo-text">
+                    <div class="brand-name">IMPOR<span>LAN</span></div>
+                    <div class="brand-tagline">Tu lancha, puerta a puerta</div>
+                </div>
+            </a>
+            <nav class="seo-nav" aria-label="Principal">
+                <div class="seo-nav-links">
+                    <a href="/">Inicio</a>
+                    <a href="/#servicios">Servicios</a>
+                    <a href="/#proceso">Proceso</a>
+                    <a href="/#cotizar">Cotizar</a>
+                    <a href="/#contacto">Contacto</a>
+                </div>
+                <div class="seo-nav-auth">
+                    <a href="/panel/" class="btn-login">Iniciar Sesion</a>
+                    <a href="/panel/" class="btn-register">Registrarse</a>
+                </div>
+            </nav>
+        </div>
+    </header>
+
+    <!-- Breadcrumbs -->
+    <nav class="breadcrumbs" aria-label="Breadcrumb">
+        <div class="container">
+            <ol class="breadcrumbs-list">
+                <li><a href="/">Inicio</a></li>
+                <li class="separator">/</li>
+                <li class="current">Política de Privacidad</li>
+            </ol>
+        </div>
+    </nav>
+
+    <!-- Hero -->
+    <section class="seo-hero">
+        <div class="container">
+            <div class="hero-icon">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="m9 12 2 2 4-4"/></svg>
+            </div>
+            <h1>Política de Privacidad</h1>
+            <p class="hero-subtitle">Cómo recopilamos, usamos y protegemos tus datos personales, y cómo puedes ejercer tus derechos conforme a la legislación chilena.</p>
+        </div>
+    </section>
+
+    <!-- Content -->
+    <main class="legal-wrap">
+        <div class="container">
+            <article class="legal-card">
+                <span class="legal-updated">Última actualización: 19 de junio de 2026</span>
+
+                <div class="legal-toc">
+                    <strong>Contenido</strong>
+                    <ol>
+                        <li><a href="#responsable">Responsable del tratamiento</a></li>
+                        <li><a href="#marco">Marco legal</a></li>
+                        <li><a href="#datos">Datos que recopilamos</a></li>
+                        <li><a href="#finalidades">Finalidades del tratamiento</a></li>
+                        <li><a href="#consentimiento">Base y consentimiento</a></li>
+                        <li><a href="#terceros">Comunicación a terceros</a></li>
+                        <li><a href="#cookies">Cookies y analítica</a></li>
+                        <li><a href="#conservacion">Conservación de los datos</a></li>
+                        <li><a href="#derechos">Tus derechos</a></li>
+                        <li><a href="#seguridad">Seguridad</a></li>
+                        <li><a href="#enlaces">Enlaces a sitios de terceros</a></li>
+                        <li><a href="#cambios">Cambios en esta política</a></li>
+                    </ol>
+                </div>
+
+                <p>En Imporlan respetamos tu privacidad y nos comprometemos a proteger los datos personales que nos confías. Esta Política explica qué información recopilamos, con qué finalidad, con quién la compartimos y cómo puedes ejercer tus derechos.</p>
+
+                <h2 id="responsable">1. Responsable del tratamiento</h2>
+                <div class="legal-id">
+                    <p><strong>Nombre comercial:</strong> Imporlan (Grupo Imporlan)</p>
+                    <p><strong>Domicilio:</strong> Santiago, Chile</p>
+                    <p><strong>Correo de contacto:</strong> <a href="mailto:contacto@imporlan.cl">contacto@imporlan.cl</a></p>
+                    <p><strong>Razón social y RUT:</strong> se incorporarán en esta sección. Para requerimientos formales, escríbenos a contacto@imporlan.cl.</p>
+                </div>
+
+                <h2 id="marco">2. Marco legal</h2>
+                <p>El tratamiento de tus datos personales se realiza conforme a la <strong>Ley N° 19.628 sobre Protección de la Vida Privada</strong> y demás normativa chilena aplicable. Cuando corresponda, adoptaremos las adecuaciones que exijan futuras reformas a la legislación de protección de datos.</p>
+
+                <h2 id="datos">3. Datos que recopilamos</h2>
+                <ul>
+                    <li><strong>Datos de identificación y contacto:</strong> nombre, correo electrónico y teléfono que nos proporcionas en formularios, cotizaciones o por WhatsApp.</li>
+                    <li><strong>Datos de tu solicitud:</strong> información sobre la embarcación de interés, presupuesto, tipo de uso y preferencias.</li>
+                    <li><strong>Datos de navegación:</strong> información técnica como dirección IP, tipo de dispositivo y páginas visitadas, mediante cookies y herramientas de analítica.</li>
+                    <li><strong>Datos de pago:</strong> los pagos se procesan a través de pasarelas externas (por ejemplo, WebPay, MercadoPago o PayPal). <strong>Imporlan no almacena los datos de tu tarjeta.</strong></li>
+                </ul>
+
+                <h2 id="finalidades">4. Finalidades del tratamiento</h2>
+                <ul>
+                    <li>Responder tus consultas y entregar cotizaciones.</li>
+                    <li>Prestar y coordinar los servicios de búsqueda, compra e importación contratados.</li>
+                    <li>Contactarte por correo electrónico o WhatsApp en relación con tu solicitud.</li>
+                    <li>Mejorar el sitio, su seguridad y la experiencia de usuario.</li>
+                    <li>Cumplir obligaciones legales y contractuales.</li>
+                </ul>
+
+                <h2 id="consentimiento">5. Base y consentimiento</h2>
+                <p>Al enviar un formulario, solicitar una cotización o contactarnos, consientes el tratamiento de tus datos para las finalidades descritas. Puedes revocar tu consentimiento en cualquier momento escribiéndonos a <a href="mailto:contacto@imporlan.cl">contacto@imporlan.cl</a>, sin que ello afecte la licitud del tratamiento previo.</p>
+
+                <h2 id="terceros">6. Comunicación a terceros</h2>
+                <p>No vendemos tus datos personales. Solo los compartimos con proveedores necesarios para ejecutar la operación o el servicio (por ejemplo, pasarelas de pago, vendedores o brokers, navieras, agentes logísticos y de internación), y siempre en la medida indispensable para la finalidad contratada o cuando lo exija la ley.</p>
+
+                <h2 id="cookies">7. Cookies y analítica</h2>
+                <p>Utilizamos cookies propias y de terceros para el funcionamiento del sitio y para fines analíticos. Puedes configurar o desactivar las cookies desde tu navegador; algunas funciones del sitio podrían verse afectadas si las deshabilitas.</p>
+
+                <h2 id="conservacion">8. Conservación de los datos</h2>
+                <p>Conservamos tus datos mientras dure la relación con Imporlan y, posteriormente, durante los plazos necesarios para cumplir obligaciones legales o atender eventuales responsabilidades. Cumplidos dichos plazos, los datos se eliminan o anonimizan.</p>
+
+                <h2 id="derechos">9. Tus derechos</h2>
+                <p>Conforme a la legislación vigente, puedes ejercer tus derechos de <strong>acceso, rectificación, cancelación (eliminación) y oposición</strong> respecto de tus datos personales. Para ello, escríbenos a <a href="mailto:contacto@imporlan.cl">contacto@imporlan.cl</a> indicando tu solicitud; podremos requerir verificar tu identidad antes de responder.</p>
+
+                <h2 id="seguridad">10. Seguridad</h2>
+                <p>Aplicamos medidas técnicas y organizativas razonables para proteger tus datos frente a accesos no autorizados, pérdida o alteración, incluida la transmisión cifrada (HTTPS) del sitio.</p>
+
+                <h2 id="enlaces">11. Enlaces a sitios de terceros</h2>
+                <p>Nuestro sitio puede contener enlaces a sitios de terceros (por ejemplo, Deckeva, Muelle Flotante o portales de embarcaciones en USA). Imporlan no es responsable de las prácticas de privacidad de dichos sitios; te recomendamos revisar sus respectivas políticas.</p>
+
+                <h2 id="cambios">12. Cambios en esta política</h2>
+                <p>Podemos actualizar esta Política para reflejar cambios legales u operativos. La versión vigente será siempre la publicada en esta página, con su fecha de última actualización. Ante dudas, escríbenos a <a href="mailto:contacto@imporlan.cl">contacto@imporlan.cl</a>.</p>
+
+                <div class="legal-note">Documento de carácter referencial. Recomendamos su revisión por asesoría legal y completar la razón social y el RUT en la sección de responsable del tratamiento.</div>
+            </article>
+        </div>
+    </main>
+
+    <!-- Footer -->
+    <footer class="seo-footer">
+        <div class="container">
+            <div class="footer-main">
+                <div class="footer-brand">
+                    <a href="/" class="footer-logo">
+                        <div class="footer-logo-icon">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                <path d="M2 21c.6.5 1.2 1 2.5 1 2.5 0 2.5-2 5-2 1.3 0 1.9.5 2.5 1 .6.5 1.2 1 2.5 1 2.5 0 2.5-2 5-2 1.3 0 1.9.5 2.5 1"/>
+                                <path d="M19.38 20A11.6 11.6 0 0 0 21 14l-9-4-9 4c0 2.9.94 5.34 2.81 7.76"/>
+                                <path d="M19 13V7a2 2 0 0 0-2-2H7a2 2 0 0 0-2 2v6"/>
+                                <path d="M12 10v4"/>
+                            </svg>
+                        </div>
+                        <div class="footer-logo-text">
+                            <div class="brand-name">IMPOR<span>LAN</span></div>
+                            <div class="brand-tagline">Tu lancha, puerta a puerta</div>
+                        </div>
+                    </a>
+                    <p class="footer-brand-description">Gestión integral de compra de embarcaciones en USA e importación de lanchas desde Estados Unidos hasta su entrega en Santiago, Chile.</p>
+                </div>
+                <div class="footer-col">
+                    <h4>Nuestras Divisiones</h4>
+                    <ul>
+                        <li><a href="/">Imporlan</a></li>
+                        <li><a href="https://www.deckeva.cl/" target="_blank" rel="noopener">Deckeva</a></li>
+                        <li><a href="https://www.muelleflotante.cl/" target="_blank" rel="noopener">Muelle Flotante</a></li>
+                    </ul>
+                </div>
+                <div class="footer-col">
+                    <h4>Contacto</h4>
+                    <ul>
+                        <li>
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="4" width="20" height="16" rx="2"/><path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/></svg>
+                            <span class="contact-text">contacto@imporlan.cl</span>
+                        </li>
+                        <li>
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"/><circle cx="12" cy="10" r="3"/></svg>
+                            <span class="contact-text">Santiago, Chile</span>
+                        </li>
+                    </ul>
+                </div>
+                <div class="footer-col">
+                    <h4>Legal</h4>
+                    <ul>
+                        <li><a href="/terminos-y-condiciones/">Términos y Condiciones</a></li>
+                        <li><a href="/politica-de-privacidad/">Política de Privacidad</a></li>
+                        <li><a href="/sitemap.xml" target="_blank" rel="noopener">Mapa del sitio</a></li>
+                    </ul>
+                    <a href="/panel/" class="footer-panel-btn">
+                        Acceder al Panel
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
+                    </a>
+                </div>
+            </div>
+            <div class="footer-bottom">
+                <p>&copy; 2026 Grupo Imporlan. Todos los derechos reservados.</p>
+                <div class="footer-legal">
+                    <a href="/terminos-y-condiciones/">Términos y Condiciones</a>
+                    <a href="/politica-de-privacidad/">Política de Privacidad</a>
+                </div>
+            </div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -328,6 +328,21 @@
         <priority>0.6</priority>
     </url>
 
+    <!-- Legal pages -->
+    <url>
+        <loc>https://www.imporlan.cl/terminos-y-condiciones/</loc>
+        <lastmod>2026-06-19</lastmod>
+        <changefreq>yearly</changefreq>
+        <priority>0.3</priority>
+    </url>
+
+    <url>
+        <loc>https://www.imporlan.cl/politica-de-privacidad/</loc>
+        <lastmod>2026-06-19</lastmod>
+        <changefreq>yearly</changefreq>
+        <priority>0.3</priority>
+    </url>
+
     <!-- TOUREVO pages (en/ and br/) moved to tourevo.cl - 301 redirects active in .htaccess -->
 
 </urlset>

--- a/terminos-y-condiciones/index.html
+++ b/terminos-y-condiciones/index.html
@@ -1,0 +1,289 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Términos y Condiciones | Imporlan</title>
+    <meta name="description" content="Términos y Condiciones de uso de los servicios de gestión, compra e importación de embarcaciones de Imporlan. Honorarios, alcances, pagos y responsabilidades.">
+    <meta name="robots" content="index, follow">
+    <meta name="author" content="Imporlan">
+    <link rel="canonical" href="https://www.imporlan.cl/terminos-y-condiciones/">
+    <link rel="alternate" hreflang="es" href="https://www.imporlan.cl/terminos-y-condiciones/">
+    <link rel="alternate" hreflang="x-default" href="https://www.imporlan.cl/terminos-y-condiciones/">
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="Términos y Condiciones | Imporlan">
+    <meta property="og:description" content="Términos y Condiciones de uso de los servicios de Imporlan.">
+    <meta property="og:url" content="https://www.imporlan.cl/terminos-y-condiciones/">
+    <meta property="og:site_name" content="Imporlan">
+    <meta property="og:locale" content="es_CL">
+    <meta property="og:image" content="https://www.imporlan.cl/images/imporlan-og.jpg">
+    <link rel="icon" type="image/svg+xml" href="/images/imporlan-favicon.svg">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../assets/seo/seo-pages.css">
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "WebPage",
+        "name": "Términos y Condiciones | Imporlan",
+        "description": "Términos y Condiciones de uso de los servicios de gestión, compra e importación de embarcaciones de Imporlan.",
+        "url": "https://www.imporlan.cl/terminos-y-condiciones/",
+        "datePublished": "2026-06-19",
+        "dateModified": "2026-06-19",
+        "inLanguage": "es-CL",
+        "publisher": { "@type": "Organization", "name": "Imporlan", "url": "https://www.imporlan.cl" }
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+            {"@type": "ListItem", "position": 1, "name": "Inicio", "item": "https://www.imporlan.cl/"},
+            {"@type": "ListItem", "position": 2, "name": "Términos y Condiciones", "item": "https://www.imporlan.cl/terminos-y-condiciones/"}
+        ]
+    }
+    </script>
+    <style>
+      /* Scoped, self-contained styling for the legal document (light, readable) */
+      .legal-wrap { background: #f1f5f9; padding: 40px 0 64px; }
+      .legal-card { max-width: 880px; margin: 0 auto; background: #fff; border: 1px solid #e2e8f0; border-radius: 16px; padding: 40px 44px; box-shadow: 0 18px 40px -24px rgba(15,23,42,.25); }
+      .legal-card .legal-updated { display: inline-block; font-size: 13px; font-weight: 600; color: #0891b2; background: #ecfeff; border: 1px solid #a5f3fc; border-radius: 9999px; padding: 5px 14px; margin-bottom: 22px; }
+      .legal-card h2 { font-size: 1.35rem; color: #0f172a; margin: 34px 0 12px; font-weight: 700; line-height: 1.3; }
+      .legal-card h2:first-of-type { margin-top: 6px; }
+      .legal-card h3 { font-size: 1.05rem; color: #1e293b; margin: 20px 0 8px; font-weight: 600; }
+      .legal-card p, .legal-card li { color: #334155; font-size: 15.5px; line-height: 1.75; }
+      .legal-card p { margin: 0 0 14px; }
+      .legal-card ul { margin: 0 0 16px; padding-left: 20px; }
+      .legal-card li { margin-bottom: 8px; }
+      .legal-card strong { color: #0f172a; }
+      .legal-card a { color: #0891b2; text-decoration: underline; }
+      .legal-id { background: #f8fafc; border: 1px solid #e2e8f0; border-left: 4px solid #06b6d4; border-radius: 10px; padding: 16px 20px; margin: 8px 0 18px; }
+      .legal-id p { margin: 4px 0; font-size: 14.5px; }
+      .legal-note { background: #fffbeb; border: 1px solid #fde68a; border-radius: 10px; padding: 14px 18px; margin: 24px 0 0; font-size: 13.5px; color: #92400e; }
+      .legal-toc { background:#f8fafc; border:1px solid #e2e8f0; border-radius:10px; padding:16px 20px; margin-bottom: 8px; }
+      .legal-toc strong { display:block; margin-bottom:8px; color:#0f172a; }
+      .legal-toc ol { margin:0; padding-left:20px; }
+      .legal-toc a { color:#0891b2; }
+      @media (max-width: 640px) { .legal-card { padding: 28px 20px; border-radius: 12px; } .legal-card h2 { font-size: 1.2rem; } }
+    </style>
+</head>
+<body>
+    <!-- Header -->
+    <header class="seo-header">
+        <div class="container">
+            <a href="/" class="seo-logo">
+                <div class="seo-logo-icon">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M2 21c.6.5 1.2 1 2.5 1 2.5 0 2.5-2 5-2 1.3 0 1.9.5 2.5 1 .6.5 1.2 1 2.5 1 2.5 0 2.5-2 5-2 1.3 0 1.9.5 2.5 1"/>
+                        <path d="M19.38 20A11.6 11.6 0 0 0 21 14l-9-4-9 4c0 2.9.94 5.34 2.81 7.76"/>
+                        <path d="M19 13V7a2 2 0 0 0-2-2H7a2 2 0 0 0-2 2v6"/>
+                        <path d="M12 10v4"/>
+                    </svg>
+                </div>
+                <div class="seo-logo-text">
+                    <div class="brand-name">IMPOR<span>LAN</span></div>
+                    <div class="brand-tagline">Tu lancha, puerta a puerta</div>
+                </div>
+            </a>
+            <nav class="seo-nav" aria-label="Principal">
+                <div class="seo-nav-links">
+                    <a href="/">Inicio</a>
+                    <a href="/#servicios">Servicios</a>
+                    <a href="/#proceso">Proceso</a>
+                    <a href="/#cotizar">Cotizar</a>
+                    <a href="/#contacto">Contacto</a>
+                </div>
+                <div class="seo-nav-auth">
+                    <a href="/panel/" class="btn-login">Iniciar Sesion</a>
+                    <a href="/panel/" class="btn-register">Registrarse</a>
+                </div>
+            </nav>
+        </div>
+    </header>
+
+    <!-- Breadcrumbs -->
+    <nav class="breadcrumbs" aria-label="Breadcrumb">
+        <div class="container">
+            <ol class="breadcrumbs-list">
+                <li><a href="/">Inicio</a></li>
+                <li class="separator">/</li>
+                <li class="current">Términos y Condiciones</li>
+            </ol>
+        </div>
+    </nav>
+
+    <!-- Hero -->
+    <section class="seo-hero">
+        <div class="container">
+            <div class="hero-icon">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6"/><path d="M16 13H8"/><path d="M16 17H8"/><path d="M10 9H8"/></svg>
+            </div>
+            <h1>Términos y Condiciones</h1>
+            <p class="hero-subtitle">Condiciones que regulan el uso del sitio y la contratación de los servicios de gestión, compra e importación de embarcaciones de Imporlan.</p>
+        </div>
+    </section>
+
+    <!-- Content -->
+    <main class="legal-wrap">
+        <div class="container">
+            <article class="legal-card">
+                <span class="legal-updated">Última actualización: 19 de junio de 2026</span>
+
+                <div class="legal-toc">
+                    <strong>Contenido</strong>
+                    <ol>
+                        <li><a href="#identificacion">Identificación del responsable</a></li>
+                        <li><a href="#objeto">Objeto y alcance del servicio</a></li>
+                        <li><a href="#honorarios">Honorarios de gestión y costos no incluidos</a></li>
+                        <li><a href="#cotizaciones">Cotizaciones, precios y tipo de cambio</a></li>
+                        <li><a href="#pagos">Formas de pago y pagos por etapas</a></li>
+                        <li><a href="#cliente">Obligaciones del cliente</a></li>
+                        <li><a href="#responsabilidad">Naturaleza del servicio y responsabilidad</a></li>
+                        <li><a href="#cancelacion">Cancelaciones y reembolsos</a></li>
+                        <li><a href="#marketplace">Marketplace y publicaciones de terceros</a></li>
+                        <li><a href="#datos">Protección de datos</a></li>
+                        <li><a href="#pi">Propiedad intelectual</a></li>
+                        <li><a href="#ley">Legislación aplicable y jurisdicción</a></li>
+                        <li><a href="#cambios">Modificaciones</a></li>
+                    </ol>
+                </div>
+
+                <p>Estos Términos y Condiciones (en adelante, los «Términos») regulan el acceso y uso del sitio <strong>www.imporlan.cl</strong> y la contratación de los servicios prestados por Imporlan. Al utilizar el sitio, solicitar una cotización o contratar cualquiera de nuestros servicios, declaras haber leído y aceptado estos Términos.</p>
+
+                <h2 id="identificacion">1. Identificación del responsable</h2>
+                <div class="legal-id">
+                    <p><strong>Nombre comercial:</strong> Imporlan (Grupo Imporlan)</p>
+                    <p><strong>Domicilio:</strong> Santiago, Chile</p>
+                    <p><strong>Correo de contacto:</strong> <a href="mailto:contacto@imporlan.cl">contacto@imporlan.cl</a></p>
+                    <p><strong>Sitio web:</strong> www.imporlan.cl</p>
+                    <p><strong>Razón social y RUT:</strong> se incorporarán en esta sección. Para constancia formal, escríbenos a contacto@imporlan.cl.</p>
+                </div>
+
+                <h2 id="objeto">2. Objeto y alcance del servicio</h2>
+                <p>Imporlan presta servicios profesionales de <strong>gestión, coordinación y acompañamiento</strong> para la búsqueda, compra e importación de embarcaciones desde Estados Unidos hacia Chile. Nuestro servicio está diseñado por etapas, que el cliente puede contratar de forma independiente o sucesiva:</p>
+                <ul>
+                    <li><strong>Plan de Búsqueda:</strong> identificación, filtrado y análisis de oportunidades según presupuesto, tipo de embarcación y objetivo de uso (valor según plan vigente).</li>
+                    <li><strong>Compra y Logística USA:</strong> acompañamiento en la gestión comercial de compra y coordinación inicial dentro de Estados Unidos.</li>
+                    <li><strong>Importación Full + Entrega Santiago:</strong> coordinación de la operación posterior a la compra hasta la entrega final de la embarcación en Santiago, Chile.</li>
+                </ul>
+                <p>Imporlan actúa como <strong>gestor y coordinador</strong> de la operación. No es propietario, vendedor ni fabricante de las embarcaciones, ni naviera, agente de aduanas o autoridad marítima.</p>
+
+                <h2 id="honorarios">3. Honorarios de gestión y costos no incluidos</h2>
+                <p>Los valores publicados corresponden <strong>exclusivamente a honorarios de gestión Imporlan</strong>. No incluyen, de forma enunciativa y no taxativa:</p>
+                <ul>
+                    <li>El valor de la embarcación.</li>
+                    <li>Inspecciones o revisiones externas.</li>
+                    <li>Transportes, fletes o seguros.</li>
+                    <li>Impuestos, derechos, gastos portuarios y aduaneros, y transporte local.</li>
+                    <li>Cualquier otro gasto de terceros necesario para ejecutar la operación.</li>
+                </ul>
+                <p>Cada operación puede requerir costos externos según la embarcación, su ubicación, dimensiones, destino y las condiciones comerciales aplicables.</p>
+
+                <h2 id="cotizaciones">4. Cotizaciones, precios y tipo de cambio</h2>
+                <p>Las cotizaciones tienen carácter <strong>referencial</strong> y pueden expresarse en pesos chilenos (CLP) y/o dólares de los Estados Unidos (USD). Los montos pueden variar según el tipo de cambio vigente, la disponibilidad de la embarcación y las condiciones de terceros. La vigencia de cada cotización será la indicada en el documento respectivo.</p>
+
+                <h2 id="pagos">5. Formas de pago y pagos por etapas</h2>
+                <p>Los honorarios de gestión podrán pagarse a través de los medios habilitados en el sitio (por ejemplo, WebPay, MercadoPago, PayPal o transferencia bancaria). El servicio puede contratarse por etapas: el cliente paga únicamente el servicio correspondiente a la etapa que decide contratar, manteniendo el control de su presupuesto en cada fase.</p>
+
+                <h2 id="cliente">6. Obligaciones del cliente</h2>
+                <ul>
+                    <li>Entregar información veraz, completa y oportuna para la prestación del servicio.</li>
+                    <li>Disponer en tiempo y forma de los fondos destinados al valor de la embarcación y a los costos de terceros.</li>
+                    <li>Adoptar las decisiones de compra que le corresponden; Imporlan no avanza a una etapa sin la aprobación del cliente.</li>
+                    <li>Utilizar el sitio conforme a la ley, la buena fe y estos Términos.</li>
+                </ul>
+
+                <h2 id="responsabilidad">7. Naturaleza del servicio y responsabilidad</h2>
+                <p>Imporlan compromete una gestión profesional y diligente de coordinación y acompañamiento. Sin perjuicio de ello, parte de la operación depende de terceros (vendedores, brokers, navieras, agentes, aseguradoras, autoridades portuarias, aduaneras y marítimas), por lo que <strong>los plazos son estimados</strong> y pueden verse afectados por factores ajenos a Imporlan. Imporlan no será responsable por hechos, demoras, defectos o incumplimientos imputables a dichos terceros, a información inexacta proporcionada por el cliente o a causas de fuerza mayor o caso fortuito.</p>
+
+                <h2 id="cancelacion">8. Cancelaciones y reembolsos</h2>
+                <p>Las condiciones de cancelación y eventuales reembolsos se evaluarán según la etapa contratada y el avance de la gestión al momento de la solicitud. Los honorarios correspondientes a gestiones ya iniciadas o ejecutadas, así como los costos de terceros ya incurridos, no son reembolsables. Para revisar tu caso, escríbenos a <a href="mailto:contacto@imporlan.cl">contacto@imporlan.cl</a>.</p>
+
+                <h2 id="marketplace">9. Marketplace y publicaciones de terceros</h2>
+                <p>El sitio puede incluir un marketplace con publicaciones de venta o arriendo de embarcaciones de terceros. Imporlan no garantiza la exactitud, disponibilidad ni el estado de dichas publicaciones, y no es parte de las transacciones que los usuarios acuerden directamente entre sí, salvo que se contrate expresamente un servicio de gestión de Imporlan.</p>
+
+                <h2 id="datos">10. Protección de datos</h2>
+                <p>El tratamiento de los datos personales se rige por nuestra <a href="/politica-de-privacidad/">Política de Privacidad</a>, que forma parte integrante de estos Términos.</p>
+
+                <h2 id="pi">11. Propiedad intelectual</h2>
+                <p>Los contenidos del sitio (textos, marcas, logotipos, diseños, imágenes y código) son de propiedad de Imporlan o de sus titulares y están protegidos por la legislación aplicable. No está permitida su reproducción o uso sin autorización previa y por escrito.</p>
+
+                <h2 id="ley">12. Legislación aplicable y jurisdicción</h2>
+                <p>Estos Términos se rigen por las leyes de la República de Chile. Cualquier controversia se someterá a los tribunales ordinarios de justicia con asiento en Santiago, sin perjuicio de los derechos que la legislación de protección al consumidor reconoce al cliente.</p>
+
+                <h2 id="cambios">13. Modificaciones</h2>
+                <p>Imporlan podrá actualizar estos Términos en cualquier momento. La versión vigente será siempre la publicada en esta página, indicando su fecha de última actualización. Para consultas, escríbenos a <a href="mailto:contacto@imporlan.cl">contacto@imporlan.cl</a>.</p>
+
+                <div class="legal-note">Documento de carácter referencial. Recomendamos su revisión por asesoría legal antes de considerarlo definitivo y completar la razón social y el RUT en la sección de identificación.</div>
+            </article>
+        </div>
+    </main>
+
+    <!-- Footer -->
+    <footer class="seo-footer">
+        <div class="container">
+            <div class="footer-main">
+                <div class="footer-brand">
+                    <a href="/" class="footer-logo">
+                        <div class="footer-logo-icon">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                <path d="M2 21c.6.5 1.2 1 2.5 1 2.5 0 2.5-2 5-2 1.3 0 1.9.5 2.5 1 .6.5 1.2 1 2.5 1 2.5 0 2.5-2 5-2 1.3 0 1.9.5 2.5 1"/>
+                                <path d="M19.38 20A11.6 11.6 0 0 0 21 14l-9-4-9 4c0 2.9.94 5.34 2.81 7.76"/>
+                                <path d="M19 13V7a2 2 0 0 0-2-2H7a2 2 0 0 0-2 2v6"/>
+                                <path d="M12 10v4"/>
+                            </svg>
+                        </div>
+                        <div class="footer-logo-text">
+                            <div class="brand-name">IMPOR<span>LAN</span></div>
+                            <div class="brand-tagline">Tu lancha, puerta a puerta</div>
+                        </div>
+                    </a>
+                    <p class="footer-brand-description">Gestión integral de compra de embarcaciones en USA e importación de lanchas desde Estados Unidos hasta su entrega en Santiago, Chile.</p>
+                </div>
+                <div class="footer-col">
+                    <h4>Nuestras Divisiones</h4>
+                    <ul>
+                        <li><a href="/">Imporlan</a></li>
+                        <li><a href="https://www.deckeva.cl/" target="_blank" rel="noopener">Deckeva</a></li>
+                        <li><a href="https://www.muelleflotante.cl/" target="_blank" rel="noopener">Muelle Flotante</a></li>
+                    </ul>
+                </div>
+                <div class="footer-col">
+                    <h4>Contacto</h4>
+                    <ul>
+                        <li>
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="4" width="20" height="16" rx="2"/><path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/></svg>
+                            <span class="contact-text">contacto@imporlan.cl</span>
+                        </li>
+                        <li>
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"/><circle cx="12" cy="10" r="3"/></svg>
+                            <span class="contact-text">Santiago, Chile</span>
+                        </li>
+                    </ul>
+                </div>
+                <div class="footer-col">
+                    <h4>Legal</h4>
+                    <ul>
+                        <li><a href="/terminos-y-condiciones/">Términos y Condiciones</a></li>
+                        <li><a href="/politica-de-privacidad/">Política de Privacidad</a></li>
+                        <li><a href="/sitemap.xml" target="_blank" rel="noopener">Mapa del sitio</a></li>
+                    </ul>
+                    <a href="/panel/" class="footer-panel-btn">
+                        Acceder al Panel
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
+                    </a>
+                </div>
+            </div>
+            <div class="footer-bottom">
+                <p>&copy; 2026 Grupo Imporlan. Todos los derechos reservados.</p>
+                <div class="footer-legal">
+                    <a href="/terminos-y-condiciones/">Términos y Condiciones</a>
+                    <a href="/politica-de-privacidad/">Política de Privacidad</a>
+                </div>
+            </div>
+        </div>
+    </footer>
+</body>
+</html>


### PR DESCRIPTION
## Resumen

Mejora de **confianza** del sitio: crea páginas **legales reales** de Términos y Condiciones y Política de Privacidad.

## Problema detectado (auditoría del home en vivo)

El footer visible del home ya enlazaba a `/terminos-y-condiciones/` y `/politica-de-privacidad/`, pero esas rutas **devolvían el shell del SPA** (mostraban el home), no contenido legal. Para un servicio de ticket alto (millones de CLP) y con formulario + pagos que recolectan datos personales, esto es una brecha de confianza y de cumplimiento.

## Cambios

- **`terminos-y-condiciones/index.html`** (nuevo): alcance del servicio por etapas, honorarios de gestión y costos no incluidos, cotizaciones/tipo de cambio, pagos por etapas, obligaciones del cliente, naturaleza del servicio y responsabilidad, cancelaciones, marketplace de terceros, propiedad intelectual, legislación chilena y jurisdicción.
- **`politica-de-privacidad/index.html`** (nuevo): datos recopilados, finalidades, comunicación a terceros, cookies, conservación, derechos del titular (acceso, rectificación, cancelación, oposición) y seguridad, conforme a la **Ley 19.628**.
- Ambas con el template de las páginas SEO (header, breadcrumb, footer, estilos compartidos `seo-pages.css`), enlaces legales correctos y divisiones a sus dominios reales (`deckeva.cl`, `muelleflotante.cl`).
- Registradas en el **deploy** (`.cpanel.yml` y `deploy-prod.sh`) — sin esto no se publicarían — y en `sitemap.xml`.

## Verificación

- `html-validate` (config del repo): **limpio** (corregido `aria-label` en nav para accesibilidad).
- Render local: ambas páginas cargan con su `<h1>` propio, 12–13 secciones y el CSS de marca resuelto.
- El fallback SPA del `.htaccess` solo aplica a rutas inexistentes, por lo que estas carpetas se sirven como páginas reales.

## Pendiente (requiere tus datos)
- Completar **razón social y RUT** en la sección de identificación (quedan marcados). Recomendable revisión por asesoría legal antes de considerarlos definitivos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EPskmfE9tY5SJMULVJyrk6)_