### PR TITLE
fix(deploy): sincronización dura del espejo a origin/main (fin de divergencias)

### DIFF
--- a/deploy-prod.sh
+++ b/deploy-prod.sh
@@ -63,11 +63,12 @@ fi
 echo "  -> Doc-root identity check passed."
 
 echo ""
-echo "[1/9] Pulling latest changes from GitHub (main)..."
+echo "[1/9] Syncing to latest GitHub main (hard sync — staging is a deploy mirror)..."
 cd "$STAGING_REPO"
-git checkout main
-git pull origin main
-echo "  -> Pull complete."
+git fetch origin main
+git checkout -f main 2>/dev/null || git checkout -B main
+git reset --hard origin/main
+echo "  -> Synced to $(git rev-parse --short HEAD)."
 
 echo ""
 echo "[2/9] Creating backup directory..."


### PR DESCRIPTION
## Problema
El repo-espejo de despliegue (`imporlan-staging`) usa `git pull`, que con `pull.ff only` + los squash-merges de los PRs a veces aborta con *"Not possible to fast-forward"* (ya pasó 3 veces). Cada vez había que arreglarlo a mano con `git reset --hard`.

## Solución
`deploy-prod.sh` paso `[1/9]` ahora hace **`git fetch` + `git reset --hard origin/main`** en lugar de `git pull`. Como el staging es solo un **espejo de despliegue** (no se desarrolla ahí), dejarlo idéntico a GitHub es lo correcto y elimina la divergencia de forma permanente.

**A partir de ahora el deploy es simplemente:**
```bash
bash deploy-prod.sh
```
(sin `git pull` manual).

Validado con `bash -n` (sintaxis correcta).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EPskmfE9tY5SJMULVJyrk6)_