### PR TITLE
fix(home): eliminar overflow horizontal / franja blanca a la derecha

### DIFF
--- a/assets/home-ux-pro.js
+++ b/assets/home-ux-pro.js
@@ -36,6 +36,9 @@
     var s = document.createElement('style');
     s.id = STYLE_ID;
     s.textContent = [
+      /* Fix pre-existing horizontal overflow caused by the off-canvas mobile drawer
+         (and any off-screen decoration): clip the x-axis without affecting vertical scroll. */
+      'html,body{overflow-x:hidden;max-width:100%;}',
       /* Scroll progress bar */
       '#imp-uxpro-progress{position:fixed;top:0;left:0;height:3px;width:100%;transform:scaleX(0);transform-origin:0 50%;background:linear-gradient(90deg,#22d3ee,#6366f1 60%,#a855f7);z-index:10000;pointer-events:none;will-change:transform;transition:transform .08s linear;}',
       '#imp-uxpro-progress::after{content:"";position:absolute;right:0;top:0;height:100%;width:60px;background:linear-gradient(90deg,transparent,rgba(168,85,247,.65));}',

--- a/index.html
+++ b/index.html
@@ -309,7 +309,7 @@
     <script defer src="/assets/header-enhancer.js?v=20260509d"></script>
     <script defer src="/assets/footer-enhancer.js?v=20260619"></script>
     <script defer src="/assets/plans-enhancer.js?v=20260509e"></script>
-    <script defer src="/assets/home-ux-pro.js?v=20260619c"></script>
+    <script defer src="/assets/home-ux-pro.js?v=20260619d"></script>
     <!-- Cross-domain partner links are now rendered by footer-enhancer.js as part of the redesigned footer -->
   </body>
 </html>


### PR DESCRIPTION
## Problema (lo que viste a la derecha)
Franja blanca a la derecha + scroll horizontal en el home. Es un **overflow horizontal de ~120px**.

## Causa
El **drawer del menú móvil** (`#imp-pro-drawer`, generado por `header-enhancer.js`) queda posicionado **fuera de pantalla a la derecha** y estira la página. **No lo causó la capa UX** (Fase 1-3): verifiqué cargando el home **con y sin** `home-ux-pro.js` y el overflow (scrollW=2040) era idéntico → es preexistente del header.

## Fix
`html,body{overflow-x:hidden;max-width:100%}` (en `home-ux-pro.js`) — recorta el eje X sin tocar el scroll vertical. Es el patrón estándar para off-canvas menus que desbordan.

## Verificación (en vivo, inyectando la versión nueva)
- Overflow **eliminado**: desktop `scrollW 2040 → 1920` (overflow=false); móvil `390=390`.
- Scroll vertical: OK.
- **Drawer móvil**: abre **idéntico** con y sin el fix (`left:47`, visible dentro del viewport) → no se rompe.
- Header fijo intacto; ESLint + `node --check` limpios.
- Cache-bust `home-ux-pro.js?v=20260619d`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EPskmfE9tY5SJMULVJyrk6)_