### PR TITLE
fix(expedientes): fallar con mensaje claro si falta el módulo de scraping y no dejar filas en blanco

### DIFF
--- a/api/orders_api.php
+++ b/api/orders_api.php
@@ -1836,7 +1836,22 @@ function createOrderFromQuotation($purchase, $storedLinks = []) {
  * @return array Resumen por fila, apto para devolver al panel.
  */
 function scrapeOrderLinkRows($pdo, $orderId, $onlyEmpty = true, $limit = 0, $rowIndex = null) {
-    require_once __DIR__ . '/link_scraper.php';
+    // Un require de un archivo ausente es un fatal: el servidor devuelve un 500
+    // en HTML que el panel ni siquiera puede parsear, y el usuario ve un error
+    // generico sin pista de la causa. Preferimos una excepcion con nombre.
+    $scraperFile = __DIR__ . '/link_scraper.php';
+    if (!file_exists($scraperFile)) {
+        throw new \RuntimeException(
+            'Falta api/link_scraper.php en el servidor. Es el modulo que extrae los datos ' .
+            'de cada link; sin el no se puede scrapear. Revisa si el antivirus del hosting ' .
+            'lo puso en cuarentena y vuelve a desplegar.'
+        );
+    }
+    require_once $scraperFile;
+
+    if (!function_exists('scrapeLinkData')) {
+        throw new \RuntimeException('api/link_scraper.php existe pero no define scrapeLinkData().');
+    }
 
     $sql = "SELECT row_index, url, title, image_url FROM order_links
             WHERE order_id = ? AND url IS NOT NULL AND TRIM(url) <> ''";
@@ -1869,6 +1884,24 @@ function scrapeOrderLinkRows($pdo, $orderId, $onlyEmpty = true, $limit = 0, $row
         if (!preg_match('/^https?:\/\//i', $url)) {
             $results[] = ['row_index' => intval($row['row_index']), 'status' => 'invalid_url'];
             continue;
+        }
+
+        // Primero guardamos lo que se deduce de la URL misma (año, marca,
+        // modelo, titulo). No usa red, es instantaneo y garantiza que la fila
+        // nunca quede en blanco si despues falla el Plan B o el servidor corta
+        // la peticion por tiempo.
+        if (function_exists('parseUrlPatterns')) {
+            try {
+                $quick = [
+                    'image_url' => null, 'location' => null, 'hours' => null,
+                    'value_usa_usd' => null, 'title' => null, 'description' => null,
+                    'engine' => null, 'make' => null, 'model' => null, 'year' => null,
+                ];
+                parseUrlPatterns($url, parse_url($url), $quick);
+                applyScrapedDataToLinkRow($pdo, $orderId, intval($row['row_index']), $quick);
+            } catch (\Throwable $e) {
+                error_log("scrapeOrderLinkRows: parseUrlPatterns fallo en {$url}: " . $e->getMessage());
+            }
         }
 
         try {


### PR DESCRIPTION
## La causa real

El rescrapeo devolvía `Error del servidor` y después `0 de 3 actualizados`. **No era el código**: `api/link_scraper.php` no existe en el servidor de producción.

```
ls /home/wwimpo/imporlan.cl/api/link_scraper.php     → No such file or directory
ls /home/wwimpo/imporlan-staging/api/link_scraper.php → -rw-r--r-- 80477 Aug 5 20:46
```

Está versionado, está en `main` y está en el clon de staging con la fecha del deploy. Producción tiene 112 archivos `.php` contra 64 de staging, o sea el deploy copia y no borra. Algo eliminó ese archivo **después** de copiarlo — la sospecha principal es el antivirus del hosting, porque 80 KB de código de scraping con cURL, user-agents falsos y cookies es un falso positivo clásico.

Un `require_once` de un archivo ausente es un error fatal, así que el endpoint devolvía un 500 en HTML que el panel no podía parsear como JSON. De ahí el mensaje genérico sin ninguna pista de la causa.

## Los cambios

**1. Fallar con nombre y apellido.** `scrapeOrderLinkRows()` verifica que el módulo exista y que defina `scrapeLinkData()`, y lanza una `RuntimeException` que dice qué archivo falta y qué revisar. El panel muestra ese texto:

> Falta api/link_scraper.php en el servidor. Es el módulo que extrae los datos de cada link; sin él no se puede scrapear. Revisa si el antivirus del hosting lo puso en cuarentena y vuelve a desplegar.

**2. No dejar filas en blanco.** Antes de intentar el scrape completo se guarda lo que se deduce de la propia URL —año, marca, modelo, título— con `parseUrlPatterns()`. No usa red y es instantáneo, así que la fila conserva el grueso de los datos aunque después falle el Plan B o el servidor corte la petición.

## Verificación

Con la URL real de IMP-00031, simulando que el scrape completo revienta:

```
resultado:  {"row_index":1,"status":"updated","fields":["title","make","model","year"]}
fila final: {"year":2016,"make":"Monterey","model":"238ss","title":"2016 Monterey 238ss super Sport"}
```

Y con el módulo ausente, el mensaje sale explícito en vez de una pantalla en blanco.

## Nota

Mi diagnóstico anterior de que el problema eran los créditos de ScrapingBee **era prematuro**. Nunca llegó a ejecutarse: el fatal ocurría antes. Una vez restaurado el archivo habrá que volver a evaluar si ScrapingBee funciona.

---
_Generated by [Claude Code](https://claude.ai/code/session_017aKXKZuJ7qZamUgimBY4HR)_