### PR TITLE
feat(scraper): leer motor, horas y precio de la descripción del anuncio

### DIFF
--- a/lib/link_scraper.php
+++ b/lib/link_scraper.php
@@ -1373,10 +1373,22 @@ function parseUrlPatterns($url, $parsedUrl, &$result) {
     }
 
     $matchedPattern = false;
-    if ($isBoatSite && preg_match('/(\d{4})-([a-z][\w-]*)-([a-z][\w-]*)/', $path, $m)) {
+    // Marca perezosa y modelo que puede empezar con digito ("258ss", "224fs"):
+    // con el patron codicioso anterior la marca se comia medio modelo
+    // ("Monterey 258ss super" / modelo "Sport"). No se notaba porque
+    // extractBoatIdentity() suele corregirlo con su lista de fabricantes, pero
+    // fallaba para cualquier marca que no este en esa lista.
+    if ($isBoatSite && preg_match('/(\d{4})-([a-z][\w-]*?)-([a-z0-9][\w-]*)/', $path, $m)) {
         $year = $m[1];
         $make = ucfirst(str_replace('-', ' ', $m[2]));
-        $model = ucfirst(str_replace('-', ' ', $m[3]));
+        // El patron es codicioso y se lleva el id del aviso pegado al modelo:
+        // ".../2016-monterey-258ss-super-sport-9831580/" daba el modelo
+        // "258ss super sport 9831580", y ese numero terminaba en la ficha del
+        // cliente. Se recorta aqui y no antes del preg_match porque el patron
+        // numerico de mas abajo (Catalina 250, Bayliner 175) necesita el id
+        // para anclar el corte entre marca y modelo.
+        $rawModel = preg_replace('/-\d{5,}$/', '', $m[3]);
+        $model = ucfirst(str_replace('-', ' ', $rawModel));
         $matchedPattern = true;
     }
     // Fallback para modelos NUMERICOS (ej. Catalina 250, Bayliner 175):

--- a/lib/link_scraper.php
+++ b/lib/link_scraper.php
@@ -1281,6 +1281,18 @@ function extractFromJinaMarkdown($md, &$result) {
         $t = trim($m[1]);
         // Limpiar sufijos comunes del sitio
         $t = preg_replace('/\s+-\s+(YachtWorld|BoatTrader|Boats\.com|Boat\s+Trader).*$/i', '', $t);
+
+        // BoatTrader titula "Used 2022 Monterey 224FS, 27517 Chapel Hill": el
+        // codigo postal y la ciudad van pegados al nombre. Sin separarlos, el
+        // modelo terminaba siendo "224FS, 27517" en la ficha del cliente y la
+        // ubicacion quedaba vacia teniendo el dato ahi mismo.
+        if (preg_match('/^(.*?),\s*(\d{5})\s+(.+)$/u', $t, $lm)) {
+            $t = trim($lm[1]);
+            if (empty($result['location'])) $result['location'] = trim($lm[3]);
+        }
+        // "Used"/"New" son estado, no parte del nombre de la embarcacion.
+        $t = preg_replace('/^(Used|New)\s+/i', '', $t);
+
         if ($t) $result['title'] = $t;
     }
 

--- a/lib/link_scraper.php
+++ b/lib/link_scraper.php
@@ -393,7 +393,11 @@ function extractFieldsFromText($bodyText, $xpath, &$result) {
     }
     if (!$result['hours']) {
         // Priority 2: "with X hours" pattern (common in FB descriptions)
-        if (preg_match('/(?:with|has|only|approximately|approx|about)\s+(\d[\d,\.]*)\s*(?:hours?|hrs?|horas?)/i', $bodyText, $m)) {
+        // Los calificadores entre el numero y "hours" son la norma en los
+        // anuncios ("93 freshwater hours", "200 original engine hours"), y sin
+        // admitirlos el dato se perdia. Se limitan a dos palabras para no
+        // saltar a una cifra de otra frase.
+        if (preg_match('/(?:with|has|only|approximately|approx|about)\s+~?\s*(\d[\d,\.]*)\s*(?:[a-z]+\s+){0,2}(?:hours?|hrs?|horas?)/i', $bodyText, $m)) {
             $val = (int) preg_replace('/[,\.]/', '', $m[1]);
             if ($val >= 10 && $val <= 30000) $result['hours'] = (string) $val;
         }
@@ -433,8 +437,12 @@ function extractFieldsFromText($bodyText, $xpath, &$result) {
         $enginePatterns = [
             // "4.3 MPI 220 hp motor" - specs before the word motor/engine (require 2+ digit hp to avoid false matches)
             '/((?:[\w\.\-]+\s+){0,4}\d{2,}\s*(?:hp|HP|cv|CV|kw|KW))\s+(?:motor|engine|outboard|inboard)\b/i',
-            // "engine: Mercruiser 4.5L 220hp" - labeled with hp/L
-            '/(?:engine|motor|propulsion|power(?:ed)?\s*by)[:\s]+([A-Z][\w\s\.\-\/]+(?:\d+\s*(?:hp|HP|cv|CV|L|ci|CI)))/i',
+            // "engine: Mercruiser 4.5L 220hp" - labeled with hp/L.
+            // La coma va en la clase a proposito: BoatTrader redacta "Powered by
+            // a MerCruiser V6, 4.5L, 250HP" y sin ella el patron cortaba en la
+            // primera coma, fallaba, y el anuncio terminaba con el motor
+            // "Mercury prop" sacado de la lista de accesorios.
+            '/(?:engine|motor|propulsion|power(?:ed)?\s*by)[:\s]+([A-Z][\w\s\.\,\-\/]+(?:\d+\s*(?:hp|HP|cv|CV|L|ci|CI)))/i',
             // "Twin Mercury 300hp" - configuration + brand + power
             '/((?:twin|single|triple|quad|inboard|outboard|sterndrive|I\/O)\s+[A-Z][\w\s\.\-\/]+(?:\d+\s*(?:hp|HP|cv|CV|L)))/i',
             // Known brand names
@@ -460,6 +468,15 @@ function extractFieldsFromText($bodyText, $xpath, &$result) {
                 // Truncate at sentence boundaries more aggressively
                 $engineVal = preg_replace('/\.\s+.*$/', '', $engineVal);
                 $engineVal = rtrim($engineVal, ' .,;:-');
+                // "Mercury prop", "Yamaha propeller": son accesorios de la lista
+                // de extras del anuncio, no el motor. Sin este descarte el
+                // patron de marcas conocidas los tomaba como motor.
+                // Se busca en cualquier posicion, no solo al final: los anuncios
+                // encadenan extras ("extra Mercury prop and dock lines") y una
+                // ficha de motor de verdad nunca menciona helices ni amarras.
+                if (preg_match('/\b(?:prop|props|propeller|propellers|helice|helices|dock\s+lines?|fenders?|anchor|cover|trailer|kit)\b/i', $engineVal)) {
+                    continue;
+                }
                 if (strlen($engineVal) >= 3 && strlen($engineVal) <= 60) {
                     $result['engine'] = $engineVal;
                     break;
@@ -1356,6 +1373,19 @@ function extractFromJinaMarkdown($md, &$result) {
         if (empty($result['engine']) && preg_match('/([A-Z][A-Za-z]+)\s+de\s+(\d+(?:\.\d+)?)\s*hp/u', $md, $em)) {
             $result['engine'] = trim($em[1]) . ' ' . $em[2] . 'hp';
         }
+    }
+
+    // Lo que queda, sacarlo de la descripcion en prosa.
+    //
+    // BoatTrader no expone al lector de Jina ni el precio ni una tabla de
+    // especificaciones — lo pinta con JavaScript — pero motor, horas y eslora
+    // sí aparecen redactados dentro del texto del anuncio ("Powered by a
+    // MerCruiser V6, 4.5L, 250HP with only 93 freshwater hours"). Reusamos el
+    // extractor de prosa que ya existe para el camino HTML en vez de duplicar
+    // heuristicas; funciona sin DOM porque cada uso de $xpath esta guardado.
+    $texto = explode('Images:', $md)[0];
+    if (strlen($texto) > 200) {
+        extractFieldsFromText($texto, null, $result);
     }
 }
 

--- a/lib/link_scraper.php
+++ b/lib/link_scraper.php
@@ -1210,7 +1210,38 @@ function extractFromStructuredData($html, &$result) {
  * Llena image_url, location, value_usa_usd, title y engine cuando estos campos
  * estan vacios. Idempotente y seguro.
  */
+/**
+ * ¿La respuesta de Jina es en realidad el muro de Cloudflare?
+ *
+ * Cuando el sitio destino bloquea, Jina igual responde HTTP 200 — el 403 va
+ * adentro del cuerpo. Sin este chequeo guardabamos "Just a moment..." como
+ * titulo de la embarcacion en la ficha del cliente.
+ */
+function jinaBlockedByChallenge($md) {
+    if (!$md) return true;
+    if (stripos($md, 'Target URL returned error 403') !== false) return true;
+    if (preg_match('/^Title:\s*Just a moment/mi', $md)) return true;
+    if (preg_match('/^Title:\s*(Attention Required|Access denied|Cloudflare)/mi', $md)) return true;
+    return false;
+}
+
 function fetchViaJinaReader($url, &$result) {
+    // Jina pasa Cloudflare de forma intermitente: en las pruebas contra los tres
+    // links del mismo expediente, uno paso y dos dieron 403. Reintentar sube
+    // bastante la tasa de exito y es gratis; el costo es un par de segundos.
+    $intentos = 3;
+    for ($i = 1; $i <= $intentos; $i++) {
+        $md = jinaFetchOnce($url);
+        if ($md !== null) {
+            extractFromJinaMarkdown($md, $result);
+            return;
+        }
+        if ($i < $intentos) sleep($i); // 1s, luego 2s
+    }
+}
+
+/** Un intento contra Jina. Devuelve el markdown, o null si no sirve. */
+function jinaFetchOnce($url) {
     $jinaUrl = 'https://r.jina.ai/' . $url;
     $ch = curl_init();
     curl_setopt_array($ch, [
@@ -1221,14 +1252,23 @@ function fetchViaJinaReader($url, &$result) {
         CURLOPT_CONNECTTIMEOUT => 10,
         CURLOPT_SSL_VERIFYPEER => true,
         CURLOPT_USERAGENT => 'Mozilla/5.0 (compatible; Imporlan-Scraper/1.0)',
-        CURLOPT_HTTPHEADER => ['Accept: text/plain, text/markdown'],
+        // Sin X-With-Images-Summary, Jina devuelve SOLO texto y descarta todas
+        // las imagenes: por eso los expedientes traian ficha completa pero
+        // ninguna foto. Con la cabecera, el mismo anuncio pasa de 2.476 bytes
+        // sin imagenes a 46.059 con 146 URLs de images.boattrader.com.
+        CURLOPT_HTTPHEADER => [
+            'Accept: text/plain, text/markdown',
+            'X-With-Images-Summary: true',
+        ],
     ]);
     $md = curl_exec($ch);
     $code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
     curl_close($ch);
-    if ($code !== 200 || !$md || strlen($md) < 300) return;
 
-    extractFromJinaMarkdown($md, $result);
+    if ($code !== 200 || !$md || strlen($md) < 300) return null;
+    if (jinaBlockedByChallenge($md)) return null;
+
+    return $md;
 }
 
 /**
@@ -1244,13 +1284,25 @@ function extractFromJinaMarkdown($md, &$result) {
         if ($t) $result['title'] = $t;
     }
 
-    // Imagen: primer ![alt](url) cuya URL es de un CDN de barcos conocido
+    // Imagen: de todas las del anuncio, la portada.
+    //
+    // Jina no respeta el orden del carrusel — en las pruebas la primera que
+    // aparecia era la -5 (interior de cabina). Los CDN de Boats Group numeran
+    // las fotos con un sufijo "-N.jpg", asi que ordenamos por ese indice y nos
+    // quedamos con la mas baja, que es la que el anuncio usa de portada.
     if (empty($result['image_url'])) {
-        if (preg_match('/!\[[^\]]*\]\((https?:\/\/(?:images\.boatsgroup\.com|images\.boattrader\.com|images\.yachtworld\.com|images\.boats\.com)\/[^\s)]+)/u', $md, $m)) {
-            $imgUrl = $m[1];
-            // Quitar query string (Jina suele agregar ?w=200 que reduce calidad)
-            if (strpos($imgUrl, '?') !== false) $imgUrl = explode('?', $imgUrl)[0];
-            $result['image_url'] = $imgUrl;
+        $cdn = '(?:images\.boatsgroup\.com|images\.boattrader\.com|images\.yachtworld\.com|images\.boats\.com)';
+        if (preg_match_all('/!\[[^\]]*\]\((https?:\/\/' . $cdn . '\/[^\s)]+)/u', $md, $mm)) {
+            $urls = array_values(array_unique($mm[1]));
+            $indice = function ($u) {
+                return preg_match('/-(\d+)\.(?:jpg|jpeg|png|webp)/i', $u, $x) ? intval($x[1]) : PHP_INT_MAX;
+            };
+            usort($urls, function ($a, $b) use ($indice) { return $indice($a) <=> $indice($b); });
+
+            // Sin query string el CDN entrega el JPEG original; los parametros
+            // del srcset (w=429&format=webp) solo lo reescalan hacia abajo.
+            $imgUrl = explode('?', $urls[0])[0];
+            if (isUsefulImage($imgUrl)) $result['image_url'] = $imgUrl;
         }
     }
 


### PR DESCRIPTION
## Problema

El expediente ya traía foto, título y ubicación, pero **MOTOR, HORAS y VALOR USA quedaban vacíos** aunque el dato estuviera a la vista en la ficha de BoatTrader.

La causa: el markdown que devuelve Jina para BoatTrader es **sólo la descripción en prosa** — sin tabla de especificaciones, sin encabezados, sin precio — y el extractor de Jina no pasaba ese texto por `extractFieldsFromText()`, que es justamente el parser de prosa que ya existe para el camino HTML. Funciona sin DOM porque cada uso de `$xpath` dentro está guardado tras un `if`.

## Defectos que aparecieron al conectarlo

Ambos visibles en los anuncios reales de IMP-00031:

- **El patrón `Powered by ...` no admitía comas**, y BoatTrader redacta `Powered by a MerCruiser V6, 4.5L, 250HP`. Al cortar en la primera coma el patrón fallaba y caía al de marcas conocidas, que tomaba `Mercury prop` de la lista de extras. **Un accesorio quedaba guardado como el motor de la embarcación.**
- **Las horas no se capturaban con un calificativo intermedio**: `93 freshwater hours`, `200 original engine hours`. Ahora se admiten hasta dos palabras entre el número y la unidad.

Se agrega además un descarte explícito de accesorios (hélices, amarras, defensas, ancla, funda, trailer) en cualquier posición del valor, porque los anuncios los encadenan: `extra Mercury prop and dock lines`.

## Verificación

Contra el markdown real de los dos anuncios que pasaron Cloudflare:

| Anuncio | Motor | Horas | Precio |
|---|---|---|---|
| 224FS | `MerCruiser V6, 4.5L, 250HP` | 93 | — |
| 238SS | `Mercury` | 190 | 44 550 |

Y siete casos de control:

| Entrada | Motor | Horas |
|---|---|---|
| `Powered by a MerCruiser V6, 4.5L, 250HP with only 93 freshwater hours` | `MerCruiser V6, 4.5L, 250HP` | 93 |
| `extra Mercury prop and dock lines` | *descartado* | — |
| `Comes with a Yamaha propeller` | *descartado* | — |
| `Engine: Mercruiser 4.5L 220hp, runs great` | `Mercruiser 4.5L 220hp` | — |
| `Twin Mercury 300hp outboards with 200 engine hours` | `Twin Mercury 300hp` | 200 |
| `Volvo Penta 5.7L 320hp inboard` | `Volvo Penta 5.7L 320hp` | — |
| `Posted 2 hours ago` | *descartado* | *descartado* |

## Limitación conocida

**El precio no se puede obtener de BoatTrader.** No aparece en ninguna parte del markdown porque el sitio lo pinta con JavaScript, y Jina no lo captura. En los anuncios donde el vendedor lo escribe dentro del texto sí se toma (238SS: USD 44.550), pero eso depende de la redacción, no del sitio.

---
_Generated by [Claude Code](https://claude.ai/code/session_017aKXKZuJ7qZamUgimBY4HR)_