### PR TITLE
feat(scraper): obtener el precio de venta real de BoatTrader

### DIFF
--- a/lib/link_scraper.php
+++ b/lib/link_scraper.php
@@ -1305,6 +1305,34 @@ function jinaFetchOnce($url, $sinCache = false) {
  * extractor generico confunde con el precio de la embarcacion. Se corta desde
  * el encabezado de la calculadora hasta el aviso legal que la cierra.
  */
+/**
+ * Precio de venta desde el payload publicitario de BoatTrader.
+ *
+ * BoatTrader no escribe el precio en el texto de la ficha — lo pinta con
+ * JavaScript, asi que el lector de Jina no lo ve — pero SI lo manda, ya
+ * estructurado, en los pixeles de seguimiento que inyecta en la pagina:
+ *
+ *   _abdk_json={"class":"bowrider","price":"49500","zip_code":"27517",...}
+ *
+ * Es la fuente mas confiable que tenemos: un campo con nombre, no una cifra
+ * suelta que haya que distinguir de la cuota del credito o de un accesorio.
+ */
+function extractBoatTraderAdPrice($md, &$result) {
+    if (!empty($result['value_usa_usd'])) return;
+    if (!preg_match_all('/_abdk_json=([^;)\s\]]+)/', $md, $mm)) return;
+
+    foreach ($mm[1] as $raw) {
+        $json = json_decode(urldecode($raw), true);
+        if (!is_array($json) || !isset($json['price'])) continue;
+
+        $precio = floatval(preg_replace('/[^\d.]/', '', (string) $json['price']));
+        if ($precio >= 1000 && $precio <= 5000000) {
+            $result['value_usa_usd'] = $precio;
+            return;
+        }
+    }
+}
+
 function jinaStripFinancingBlock($md) {
     $patrones = [
         '/Here is what your monthly payment might look like.*?(?:See Important Disclosure[^\n]*)/su',
@@ -1416,6 +1444,10 @@ function extractFromJinaMarkdown($md, &$result) {
     // toda la cotizacion de importacion del cliente. Se corta ese bloque antes
     // de buscar cualquier cifra.
     $md = jinaStripFinancingBlock($md);
+
+    // Fuente preferida: el payload de publicidad de BoatTrader, que lleva el
+    // precio como dato estructurado y no como texto suelto.
+    extractBoatTraderAdPrice($md, $result);
 
     if (empty($result['value_usa_usd']) && preg_match_all('/\$\s?(\d{1,3}(?:,\d{3})+)(?!\.\d)/', $md, $pm)) {
         $candidatos = [];


### PR DESCRIPTION
## Problema

El campo VALOR USA (USD) salía vacío en casi todas las fichas, y cuando salía era el **monto del préstamo** del simulador de crédito de BoatTrader — un 10% por debajo del precio real. Ese campo alimenta el cálculo de aranceles, IVA y precio final de la cotización del cliente.

## Solución

BoatTrader no escribe el precio en el texto de la ficha —lo pinta con JavaScript, así que el lector de Jina no lo ve— pero **sí lo manda ya estructurado** en los píxeles de seguimiento publicitario que inyecta en la página:

```
_abdk_json={"class":"bowrider","price":"49500","zip_code":"27517","state":"north carolina",...}
```

Es la fuente más confiable disponible: un campo con nombre, no una cifra suelta que haya que distinguir de la cuota del crédito o del precio de un accesorio. Se usa como fuente principal; el rastreo de texto queda como respaldo.

## Verificación

Contra los dos anuncios del expediente IMP-00031, ambos con precio publicado de **USD 49.500** (confirmado en la ficha visible de BoatTrader):

| Anuncio | Antes | Ahora |
|---|---|---|
| 238SS | 44 550 *(el préstamo)* | **49 500** ✓ |
| 224FS | vacío | **49 500** ✓ |

Y cuatro controles:

| Caso | Resultado |
|---|---|
| Payload con precio | `62900` ✓ |
| Payload sin campo `price` | vacío ✓ |
| Payload corrupto (JSON inválido) | vacío ✓ |
| Bloque de financiamiento aislado | vacío ✓ |

---
_Generated by [Claude Code](https://claude.ai/code/session_017aKXKZuJ7qZamUgimBY4HR)_